### PR TITLE
change tags-display to non-destructively sort tags

### DIFF
--- a/ekg.el
+++ b/ekg.el
@@ -729,7 +729,7 @@ Does not include any trash tags."
   "Return a propertized representation of TAGS, a list.
 The tags are separated by spaces."
   (mapconcat (lambda (tag) (propertize tag 'face 'ekg-tag))
-             (sort tags #'string<) " "))
+             (sort (seq-copy tags) #'string<) " "))
 
 (defun ekg-display-note (note)
   "Display NOTE in buffer."


### PR DESCRIPTION
First off, thanks for the package - I really like the concept!

This is an attempt to fix an issue with destructive sorting of tag lists when calling`ekg-tags-display`, which can influence operations holding a reference to the provided tag list (notably `ekg--show-notes`). A quick demonstration of the problem can be done with this code (when run without my suggested patch):

```elisp
(let ((ekg-db-file "tmp.sql")
      (tags '("tags/a" "tags/b")))
  (ekg--close)
  (when (file-exists-p ekg-db-file)
    (delete-file ekg-db-file))
  (mapcar #'ekg-save-note
	  (list (ekg-note-create "a" ekg-capture-default-mode
				 '("tag/a"))
		(ekg-note-create "b" ekg-capture-default-mode
				 '("tag/b"))))
  (call-interactively #'ekg-show-notes-with-any-tags))
```

If the tags are selected in order ("tags/a" "tags/b") then the resulting buffer displays as expected. But if chosen ("tags/b" "tags/a") then only "tags/b" is shown b/c the reference to tags in `notes-func` generated by `ekg-show-notes-any-tags` (i.e. [here](https://github.com/ahyatt/ekg/blob/8ccc7ba2b8e862283aa59b15d79dd9f60be830f0/ekg.el#L878)) is now incorrect.

I'm not much of an elisp programmer, so I'm not sure if my proposed solution of just creating a sequence copy in the tags display function is appropriate. But I think it at least has the benefit of being fairly defensive in prevent unintended issues with any client functions in the future.