### PR TITLE
Add ekg-capture-and-continue

### DIFF
--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -153,7 +153,7 @@ Title: An example URL
 A final way to capture notes comes from a buffer that is viewing a list of notes, in =ekg-notes-mode=. You can call =ekg-notes-create=, which will capture a new note with whatever tags (if any) are associated with the notes buffer.
 
 #+texinfo: @noindent
-To save any note that is being captured, press =C-c C-c= or call =ekg-capture-finalize=. To cancel, just kill the buffer.
+To save any note that is being captured, press =C-c C-c= or call =ekg-capture-finalize=. If you want to save the note but continue editing it, press =C-x C-s=. To cancel, just kill the buffer.
 ** Templates
 Ekg comes with a built-in way to have templates. When a note adds a tag, ekg searches for notes with both the tag added, and the tag "template". Any note with those two tags will be added by default to the text of the buffer.
 

--- a/ekg.el
+++ b/ekg.el
@@ -350,6 +350,7 @@ not supplied, we use a default of 10."
 (defvar ekg-capture-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map "\C-c\C-c" #'ekg-capture-finalize)
+    (define-key map (kbd "C-x C-s") #'ekg-capture-and-continue)
     map)
   "Key map for `ekg-capture-mode', a minor mode.
 This is used when capturing new notes.")
@@ -770,6 +771,12 @@ The metadata fields are comma separated."
                           (seq-intersection (ekg-note-tags note)
                                             ekg-notes-tags))
                  (ewoc-enter-last ekg-notes-ewoc note))))))
+
+(defun ekg-capture-and-continue ()
+  "Store the current note and continue editing the buffer."
+  (interactive nil ekg-capture-mode)
+  (ekg--update-from-metadata)
+  (ekg--save-note-in-buffer))
 
 (defun ekg-tag-trash-p (tag)
   "Return non-nil if TAG is part of the trash."


### PR DESCRIPTION
Thanks for ekg, it looks promising for structured note taking!

For when writing long form notes, we want to be able to store the note without closing the buffer. Use the same key binding as save-buffer.

- Do we want to update the message to include the ekg-capture-and-continue command along the ekg-capture-finish one?
- Do we want C-c C-k to abort the capture process? I've just been killing the buffer tbh. 

P.D. Please consider enabling discussions for things like workflow questions

