### PR TITLE
ekg-show-notes-latest-captured: Ensure database is connected

### DIFF
--- a/ekg.el
+++ b/ekg.el
@@ -1040,6 +1040,7 @@ notes to show. But with an prefix ARG, ask the user."
   (interactive (list (if current-prefix-arg
                          (read-number "Number of notes to display: ")
                        ekg-notes-size)))
+  (ekg--connect)
   (ekg-setup-notes-buffer
    "Latest captured notes"
    (lambda ()


### PR DESCRIPTION
If I call `ekg-show-notes-latest-captured' without first having called another function that connects to ekg database I get an error. This fixes that issue.

We might want to consider a `ekg-with-db` macro, similar to magit-with-editor and other macros that ensure a resource is available.