### PR TITLE
Replace `kill-line` with `delete-line` to avoid polluting kill-ring

### DIFF
--- a/ekg.el
+++ b/ekg.el
@@ -801,7 +801,7 @@ delete from the end of the metadata, we need to fix it back up."
       (save-excursion
         (forward-line -1)
         (while (looking-at (rx (seq line-start (zero-or-more space) line-end)))
-          (kill-line)
+          (delete-line)
           (forward-line -1))))
     (when (= (overlay-end overlay)
              (buffer-end 1))


### PR DESCRIPTION
As commit message suggested, `kill-line' pollutes kill-ring, we try to avoid that.