### PR TITLE
Added ability to delete a note without a pompt

### DIFF
--- a/ekg.el
+++ b/ekg.el
@@ -1236,15 +1236,20 @@ tags."
   (interactive nil ekg-notes-mode)
   (ekg-edit (ekg--current-note-or-error)))
 
-(defun ekg-notes-delete ()
-  "Delete the current note."
-  (interactive nil ekg-notes-mode)
-  (let ((note (ekg--current-note-or-error))
-        (inhibit-read-only t))
-    (when (y-or-n-p "Are you sure you want to delete this note?")
-      (ekg-note-trash note)
-      (ewoc-delete ekg-notes-ewoc (ewoc-locate ekg-notes-ewoc))
-      (ekg--note-highlight))))
+(defun ekg-notes-delete (arg)
+  "Delete the current note.
+With a `C-u' prefix silently delete the current note without a prompt."
+  (interactive "P" ekg-notes-mode)
+  (let* ((note (ekg--current-note-or-error))
+         (inhibit-read-only t)
+         (delete-note (lambda ()
+			(progn (ekg-note-trash note)
+			       (ewoc-delete ekg-notes-ewoc (ewoc-locate ekg-notes-ewoc))
+			       (ekg--note-highlight)))))
+    (if arg
+        (funcall delete-note)
+      (when (y-or-n-p "Are you sure you want to delete this note?")
+        (funcall delete-note)))))
 
 (defun ekg-notes-browse ()
   "If the note is about a browseable resource, browse to it.

--- a/ekg.el
+++ b/ekg.el
@@ -1238,18 +1238,14 @@ tags."
 
 (defun ekg-notes-delete (arg)
   "Delete the current note.
-With a `C-u' prefix silently delete the current note without a prompt."
+With a `C-u' prefix or when ARG is non-nil, silently delete the current note without a prompt."
   (interactive "P" ekg-notes-mode)
-  (let* ((note (ekg--current-note-or-error))
-         (inhibit-read-only t)
-         (delete-note (lambda ()
-			(progn (ekg-note-trash note)
-			       (ewoc-delete ekg-notes-ewoc (ewoc-locate ekg-notes-ewoc))
-			       (ekg--note-highlight)))))
-    (if arg
-        (funcall delete-note)
-      (when (y-or-n-p "Are you sure you want to delete this note?")
-        (funcall delete-note)))))
+  (let ((note (ekg--current-note-or-error))
+        (inhibit-read-only t))
+    (when (or arg (y-or-n-p "Are you sure you want to delete this note?"))
+      (ekg-note-trash note)
+      (ewoc-delete ekg-notes-ewoc (ewoc-locate ekg-notes-ewoc))
+      (ekg--note-highlight))))
 
 (defun ekg-notes-browse ()
   "If the note is about a browseable resource, browse to it.


### PR DESCRIPTION
Quick deletion a note using the universal argument: `C-u d`.
The user can also assign a custom keybinding for quick deletion. For example, `(define-key ekg-notes-mode-map (kbd "M-d") (lambda () (interactive) (ekg-notes-delete t)))`