### PR TITLE
Update doc for name changes in b45efb0 and 71c0641

### DIFF
--- a/README.org
+++ b/README.org
@@ -136,40 +136,40 @@ Global commands, can be run everywhere, and most should be bound to useful keybi
 
 These are also global commands, but for more occasional or specialized uses:
 
-| Command        | Description                                                |
-|----------------+------------------------------------------------------------|
-| =ekg-rename-tag= | Rename a tag, updating all references to it                |
-| =ekg-upgrade-db= | After upgrading, update any obsoletely stored data         |
-| =ekg-clean-db=   | Remove unused data from the database, including empty tags |
+| Command                 | Description                                                |
+|-------------------------+------------------------------------------------------------|
+| =ekg-global-rename-tag= | Rename a tag, updating all references to it                |
+| =ekg-upgrade-db=        | After upgrading, update any obsoletely stored data         |
+| =ekg-clean-db=          | Remove unused data from the database, including empty tags |
 
 Commands relevant to capture buffers:
 
-| Command                 | Description                        |
-|-------------------------+------------------------------------|
-| =ekg-capture-change-mode= | Change note major-mode             |
-| =ekg-capture-finalize=  | Finish and save (bound to =C-c C-c=) |
+| Command                | Description                          |
+|------------------------+--------------------------------------|
+| =ekg-change-mode=      | Change note major-mode               |
+| =ekg-capture-finalize= | Finish and save (bound to =C-c C-c=) |
 
 Commands relevant to edit buffers:
 
-| Command           | Description                        |
-|-------------------+------------------------------------|
+| Command             | Description                          |
+|---------------------+--------------------------------------|
+| =ekg-change-mode=   | Change note major-mode               |
 | =ekg-edit-finalize= | Finish and save (bound to =C-c C-c=) |
 
 Commands relevant to note view buffers:
 
-| Command                         | Description                                                               | Binding |
-|---------------------------------+---------------------------------------------------------------------------+---------|
-| =ekg-notes-tag=                   | Open another tag buffer selecting from tags of current note               | =t=       |
-| =ekg-notes-open=                  | Edit the currently selected note                                          | =o=       |
-| =ekg-notes-delete=                | Delete the currently selected note                                        | =d=       |
-| =ekg-notes-remove=                | Remove the tag buffer's tags from the currently selected note             | =r=       |
-| =ekg-notes-browse=                | Open the resource, if one exists                                          | =b=       |
-| =ekg-notes-select-and-browse-url= | Select from the URLs in the current note buffer, and browse.              | =B=       |
-| =ekg-notes-refresh=               | Refresh the tag, refetching all the data displayed                        | =g=       |
-| =ekg-notes-create=                | Add a note with all the tags displayed in the buffer                      | =c=       |
-| =ekg-notes-next=                  | Move selection to the next note                                           | =n=       |
-| =ekg-notes-previous=              | Move selection to the previous note                                       | =p=       |
-| =ekg-notes-any-note-tags=         | Open another tag buffer showing any of the tags in the current note       | =a=       |
-| =ekg-notes-any-tags=              | Open another tag buffer showing any of the tags in any note in the buffer | =A=       |
-| ekg-notes-kill                  | Kill a note from the current view (does not change the database)          | k       |
-
+| Command                           | Description                                                               | Binding |
+|-----------------------------------+---------------------------------------------------------------------------+---------|
+| =ekg-notes-tag=                   | Open another tag buffer selecting from tags of current note               | =t=     |
+| =ekg-notes-open=                  | Edit the currently selected note                                          | =o=     |
+| =ekg-notes-delete=                | Delete the currently selected note                                        | =d=     |
+| =ekg-notes-remove=                | Remove the tag buffer's tags from the currently selected note             | =r=     |
+| =ekg-notes-browse=                | Open the resource, if one exists                                          | =b=     |
+| =ekg-notes-select-and-browse-url= | Select from the URLs in the current note buffer, and browse.              | =B=     |
+| =ekg-notes-refresh=               | Refresh the tag, refetching all the data displayed                        | =g=     |
+| =ekg-notes-create=                | Add a note with all the tags displayed in the buffer                      | =c=     |
+| =ekg-notes-next=                  | Move selection to the next note                                           | =n=     |
+| =ekg-notes-previous=              | Move selection to the previous note                                       | =p=     |
+| =ekg-notes-any-note-tags=         | Open another tag buffer showing any of the tags in the current note       | =a=     |
+| =ekg-notes-any-tags=              | Open another tag buffer showing any of the tags in any note in the buffer | =A=     |
+| =ekg-notes-kill=                  | Kill a note from the current view (does not change the database)          | =k=     |

--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -137,8 +137,8 @@ Ekg makes some effort to make sure that the user doesn't accidentally extend the
 Below is the property section is the note section. The text could be anything (or nothing). This is the body text of the note, where you write down whatever
 you want to note about, that is relevant to the tags for the note.
 
-There are three modes for the note text: =text-mode=, =markdown-mode=, and =org-mode=. More can be added by customizing the variable ~ekg-capture-acceptable-modes~, just
-make sure its a mode that makes sense for notes. The default mode is configured in ~ekg-capture-default-mode~, but can be changed when capturing with the command =ekg-capture-change-mode=.
+There are three modes for the note text: =text-mode=, =markdown-mode=, and =org-mode=. More can be added by customizing the variable ~ekg-acceptable-modes~, just
+make sure its a mode that makes sense for notes. The default mode is configured in ~ekg-capture-default-mode~, but can be changed when capturing with the command =ekg-change-mode=.
 ** A warning about org-mode
 Org-mode notes are primarily to use org-mode formatting on. Org-mode has a lot of funtionality, but much of it depends on the assumption that the buffer is all for use by org-mode (not true in this case, because of the properties portion), and the assumption that the buffer is visiting a file, which is also not true. In particular, attachments will not work, and ekg-notes cannot be added to the agenda.
 * Capturing notes

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -320,8 +320,8 @@ Ekg makes some effort to make sure that the user doesn't accidentally extend the
 Below is the property section is the note section. The text could be anything (or nothing). This is the body text of the note, where you write down whatever
 you want to note about, that is relevant to the tags for the note.
 
-There are three modes for the note text: @samp{text-mode}, @samp{markdown-mode}, and @samp{org-mode}. More can be added by customizing the variable @code{ekg-capture-acceptable-modes}, just
-make sure its a mode that makes sense for notes. The default mode is configured in @code{ekg-capture-default-mode}, but can be changed when capturing with the command @samp{ekg-capture-change-mode}.
+There are three modes for the note text: @samp{text-mode}, @samp{markdown-mode}, and @samp{org-mode}. More can be added by customizing the variable @code{ekg-acceptable-modes}, just
+make sure its a mode that makes sense for notes. The default mode is configured in @code{ekg-capture-default-mode}, but can be changed when capturing with the command @samp{ekg-change-mode}.
 
 @node A warning about org-mode
 @section A warning about org-mode


### PR DESCRIPTION
Previously:
b45efb0: `ekg-rename-tag` renamed to `ekg-global-rename-tag`
71c0641: `ekg-capture-acceptable-mode` renamed to `ekg-acceptable-mode`
71c0641: `ekg-capture-change-mode` renamed to `ekg-change-mode`

This PR updates the related doc.