### PR TITLE
Use key/val parameter in `ekg-note-create` & `ekg-capture`

### DIFF
--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -329,7 +329,7 @@ The ekg package is designed to be easy to integrate with.  For example, if you w
   #+begin_src emacs-lisp
   (defun my/log-to-ekg (text)
     "Log TEXT as a note to EKG's date"
-    (ekg-save-note (ekg-note-create text 'text-mode `(,(ekg-tag-for-date) "log"))))
+    (ekg-save-note (ekg-note-create :text text :mode 'text-mode :tags `(,(ekg-tag-for-date) "log"))))
 #+end_src
 
 #+texinfo: @noindent
@@ -343,7 +343,7 @@ If you wanted to re-use an existing note and append to it, you can do that as we
         (progn
           (setf (ekg-note-text (car notes)) (concat (ekg-note-text (car notes)) "\n" text))
           (ekg-save-note (car notes)))
-      (ekg-save-note (ekg-note-create text 'text-mode `(,(ekg-tag-for-date) "log"))))))
+      (ekg-save-note (ekg-note-create :text text :mode 'text-mode :tags `(,(ekg-tag-for-date) "log"))))))
 #+end_src
 
 There isn't a special API, but the basic defuns such as ~ekg-save-note~, ~ekg-note-create-text~, ~ekg-get-notes-with-tags~, ~ekg-get-note-with-id~, along with the struct ~ekg-note~ are good starting points.  Capturing notes in different ways can be done by wrapping ~ekg-capture~, and is how functions such as ~ekg-capture-url~ work.

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -586,7 +586,7 @@ The ekg package is designed to be easy to integrate with.  For example, if you w
 @lisp
 (defun my/log-to-ekg (text)
   "Log TEXT as a note to EKG's date"
-  (ekg-save-note (ekg-note-create text 'text-mode `(,(ekg-tag-for-date) "log"))))
+  (ekg-save-note (ekg-note-create :text text :mode 'text-mode :tags `(,(ekg-tag-for-date) "log"))))
 @end lisp
 
 @noindent
@@ -600,7 +600,7 @@ If you wanted to re-use an existing note and append to it, you can do that as we
         (progn
           (setf (ekg-note-text (car notes)) (concat (ekg-note-text (car notes)) "\n" text))
           (ekg-save-note (car notes)))
-      (ekg-save-note (ekg-note-create text 'text-mode `(,(ekg-tag-for-date) "log"))))))
+      (ekg-save-note (ekg-note-create :text text :mode 'text-mode :tags `(,(ekg-tag-for-date) "log"))))))
 @end lisp
 
 There isn't a special API, but the basic defuns such as @code{ekg-save-note}, @code{ekg-note-create-text}, @code{ekg-get-notes-with-tags}, @code{ekg-get-note-with-id}, along with the struct @code{ekg-note} are good starting points.  Capturing notes in different ways can be done by wrapping @code{ekg-capture}, and is how functions such as @code{ekg-capture-url} work.

--- a/ekg-logseq-test.el
+++ b/ekg-logseq-test.el
@@ -80,7 +80,7 @@
       (should (equal '("tag1") (ekg-note-tags note))))))
 
 (ert-deftest ekg-logseq-test-note-to-logseq ()
-  (let ((note (ekg-note-create "line1\nline2\n" 'org-mode '("tag1" "tag2" "tag3"))))
+  (let ((note (ekg-note-create :text "line1\nline2\n" :mode 'org-mode :tags '("tag1" "tag2" "tag3"))))
     (setf (ekg-note-id note) "123")
     (setf (ekg-note-modified-time note) 123456789)
     (should (equal
@@ -91,7 +91,7 @@
              (ekg-logseq-note-to-logseq-md note "tag3")))))
 
 (ert-deftest ekg-logseq-test-note-to-logseq-with-inlines ()
-  (let ((note (ekg-note-create " " 'org-mode '("tag1" "tag2" "tag3"))))
+  (let ((note (ekg-note-create :text " " :mode 'org-mode :tags '("tag1" "tag2" "tag3"))))
     (setf (ekg-note-id note) "123")
     (setf (ekg-note-modified-time note) 1682139975)
     (setf (ekg-note-creation-time note) 1682053575)
@@ -106,7 +106,7 @@
              (ekg-logseq-note-to-logseq-md note "tag3")))))
 
 (ert-deftest ekg-logseq-test-note-with-resource-and-title-to-logseq ()
-  (let ((note (ekg-note-create "line1\nline2\n" 'org-mode '("tag1" "tag2" "tag3"))))
+  (let ((note (ekg-note-create :text "line1\nline2\n" :mode 'org-mode :tags '("tag1" "tag2" "tag3"))))
     (setf (ekg-note-id note) "http://www.example.com")
     (setf (ekg-note-modified-time note) 123456789)
     (setf (ekg-note-properties note) '(:titled/title "Title"))
@@ -118,7 +118,7 @@
              (ekg-logseq-note-to-logseq-md note "tag3")))))
 
 (ert-deftest ekg-logseq-test-note-to-logseq-org-demotion ()
-  (let ((note (ekg-note-create "* Heading 1\n* Heading 2" 'org-mode nil)))
+  (let ((note (ekg-note-create :text "* Heading 1\n* Heading 2" :mode 'org-mode :tags nil)))
     (setf (ekg-note-id note) "123")
     (setf (ekg-note-modified-time note) 123456789)
     (should (equal
@@ -126,10 +126,10 @@
              (ekg-logseq-note-to-logseq-org note "tag3")))))
 
 (ert-deftest ekg-logseq-test-notes-to-logseq ()
-  (let ((note1 (ekg-note-create "note1" 'org-mode '("a" "b" "c")))
-        (note2 (ekg-note-create "note2" 'org-mode '("b" "a" "c")))
-        (note3 (ekg-note-create "" 'org-mode '("a" "b" "c")))
-        (note4 (ekg-note-create "note4" 'org-mode '("a" "b" "c" "trash/d"))))
+  (let ((note1 (ekg-note-create :text "note1" :mode 'org-mode :tags '("a" "b" "c")))
+        (note2 (ekg-note-create :text "note2" :mode 'org-mode :tags '("b" "a" "c")))
+        (note3 (ekg-note-create :text "" :mode 'org-mode :tags '("a" "b" "c")))
+        (note4 (ekg-note-create :text "note4" :mode 'org-mode :tags '("a" "b" "c" "trash/d"))))
     (setf (ekg-note-id note1) "1")
     (setf (ekg-note-modified-time note1) 123456789)
     (setf (ekg-note-id note4) "4")
@@ -162,7 +162,7 @@
 
 (ekg-deftest ekg-logseq-test-tags-with-notes-modified-since ()
   (cl-flet ((create (time tags)
-              (let ((note (ekg-note-create "" 'org-mode tags)))
+              (let ((note (ekg-note-create :text "" :mode 'org-mode :tags tags)))
                 (cl-letf (((symbol-function 'time-convert)
                            (lambda (&rest _) time)))
                   (ekg-save-note note)))))

--- a/ekg-logseq.el
+++ b/ekg-logseq.el
@@ -339,10 +339,10 @@ TAG is the current tag being imported in logseq."
                     (rx (seq "{{embed" (* space) "(("
                              (group-n 1 (1+ (not ")"))) "))}}"))
                     "%(transclude-note \"\\1\")" text)))
-         (note (ekg-note-create (car in-cons)
-                                (when (eq major-mode 'org-mode)
-                                  'org-mode 'markdown-mode)
-                                (cons tag (ekg-logseq--to-import-tags text)))))
+         (note (ekg-note-create :text (car in-cons)
+                                :mode (when (eq major-mode 'org-mode)
+                                        'org-mode 'markdown-mode)
+                                :tags (cons tag (ekg-logseq--to-import-tags text)))))
     (setf (ekg-note-inlines note)
           ;; These must all be transclusion commands, check each id (the first
           ;; argument) against the database to understand whether it should be

--- a/ekg-org-roam.el
+++ b/ekg-org-roam.el
@@ -114,16 +114,16 @@ However, we do pay attention to
             (setq tags-from-links (ekg-org-roam-import--tags-from-links))
             (triples-with-transaction ekg-db
               (let* ((note (ekg-note-create
-                           text
-                           'org-mode
-                           (seq-difference (seq-uniq
-                                            (cons
-                                             (ekg-org-roam-import-title-to-tag (org-roam-node-title node) (org-roam-node-tags node))
-                                             tags-from-links))
-                                           (seq-union ekg-org-roam-import-tag-to-ignore
-                                                      ekg-org-roam-import-tag-to-prefix
-                                                      #'equal)
-                                           #'equal))))
+                            :text text
+                            :mode 'org-mode
+                            :tags (seq-difference (seq-uniq
+                                                   (cons
+                                                    (ekg-org-roam-import-title-to-tag (org-roam-node-title node) (org-roam-node-tags node))
+                                                    tags-from-links))
+                                                  (seq-union ekg-org-roam-import-tag-to-ignore
+                                                             ekg-org-roam-import-tag-to-prefix
+                                                             #'equal)
+                                                  #'equal))))
                 (setf (ekg-note-id note) (org-roam-node-id node))
                 (when (org-roam-node-refs node)
                   (setf (ekg-note-properties note) `(:reference/url ,(org-roam-node-refs node))))

--- a/ekg-test.el
+++ b/ekg-test.el
@@ -28,7 +28,7 @@
 (require 'ekg-test-utils)
 
 (ekg-deftest ekg-test-note-lifecycle ()
-  (let ((note (ekg-note-create "Test text" 'text-mode '("tag1" "tag2"))))
+  (let ((note (ekg-note-create :text "Test text" :mode 'text-mode :tags '("tag1" "tag2"))))
     (ekg-save-note note)
     ;; We should have an ID now.
     (should (ekg-note-id note))
@@ -46,14 +46,14 @@
 (ekg-deftest ekg-test-tags ()
   (should-not (ekg-tags))
   ;; Make sure we trim and lowercase all tags.
-  (ekg-save-note (ekg-note-create "" 'text-mode '(" a" " B ")))
+  (ekg-save-note (ekg-note-create :text "" :mode 'text-mode :tags '(" a" " B ")))
   (should (equal (sort (ekg-tags) #'string<) '("a" "b")))
   (should (equal (ekg-tags-including "b") '("b")))
   (should (string= (ekg-tags-display '("a" "b")) "a b")))
 
 (ekg-deftest ekg-test-org-link-to-id ()
   (require 'ol)
-  (let* ((note (ekg-note-create "" 'text-mode '("a" "b")))
+  (let* ((note (ekg-note-create :text "" :mode 'text-mode :tags '("a" "b")))
          (note-buf (ekg-edit note)))
     (unwind-protect
      (progn
@@ -74,7 +74,7 @@
 
 (ekg-deftest ekg-test-org-link-to-tags ()
   (require 'ol)
-  (ekg-save-note (ekg-note-create "" 'text-mode '("a" "b")))
+  (ekg-save-note (ekg-note-create :text "" :mode 'text-mode :tags '("a" "b")))
   (ekg-show-notes-with-any-tags '("a" "b"))
   (let* ((tag-buf (get-buffer "*ekg tags (any): a b*")))
     (unwind-protect
@@ -110,30 +110,30 @@
 
 (ekg-deftest ekg-test-sort-nondestructive ()
   (mapc #'ekg-save-note
-      (list (ekg-note-create "a" ekg-capture-default-mode '("tag/a"))
-            (ekg-note-create "b" ekg-capture-default-mode '("tag/b"))))
+      (list (ekg-note-create :text "a" :mode ekg-capture-default-mode :tags '("tag/a"))
+            (ekg-note-create :text "b" :mode ekg-capture-default-mode :tags '("tag/b"))))
   (ekg-show-notes-with-any-tags '("tag/b" "tag/a"))
   (should (string= (car (ewoc-get-hf ekg-notes-ewoc)) "tags (any): tag/a tag/b")))
 
 (ekg-deftest ekg-test-note-roundtrip ()
   (let ((text "foo\n\tbar \"baz\" ☃"))
-    (ekg-save-note (ekg-note-create text #'text-mode '("test")))
+    (ekg-save-note (ekg-note-create :text text :mode #'text-mode :tags '("test")))
     (let ((note (car (ekg-get-notes-with-tag "test"))))
       (should (ekg-note-id note))
       (should (equal text (ekg-note-text note)))
       (should (equal 'text-mode (ekg-note-mode note))))))
 
 (ekg-deftest ekg-test-templating ()
-  (ekg-save-note (ekg-note-create "ABC" #'text-mode '("test" "template")))
-  (ekg-save-note (ekg-note-create "DEF" #'text-mode '("test" "template")))
+  (ekg-save-note (ekg-note-create :text "ABC" :mode #'text-mode :tags '("test" "template")))
+  (ekg-save-note (ekg-note-create :text "DEF" :mode #'text-mode :tags '("test" "template")))
   (let ((ekg-note-add-tag-hook '(ekg-on-add-tag-insert-template)))
-    (ekg-capture '("test"))
+    (ekg-capture :tags '("test"))
     (let ((text (substring-no-properties (buffer-string))))
       (should (string-match (rx (literal "ABC")) text))
       (should (string-match (rx (literal "DEF")) text)))))
 
 (ekg-deftest ekg-test-get-notes-with-tags ()
-  (ekg-save-note (ekg-note-create "ABC" #'text-mode '("foo" "bar")))
+  (ekg-save-note (ekg-note-create :text "ABC" :mode #'text-mode :tags '("foo" "bar")))
   (should-not (ekg-get-notes-with-tags '("foo" "none")))
   (should-not (ekg-get-notes-with-tags '("none" "foo")))
   (should (= (length (ekg-get-notes-with-tags '("bar" "foo"))) 1)))
@@ -159,8 +159,8 @@
                              (car ex-cons) (cdr ex-cons)))))))
 
 (ekg-deftest ekg-test-transclude ()
-  (let ((note1 (ekg-note-create "text1 text2" 'org-mode nil))
-        (note2 (ekg-note-create "text3 text4" 'text-mode nil)))
+  (let ((note1 (ekg-note-create :text "text1 text2" :mode 'org-mode :tags nil))
+        (note2 (ekg-note-create :text "text3 text4" :mode 'text-mode :tags nil)))
     (ekg-save-note note1)
     (ekg-save-note note2)
     (let ((ex-cons (ekg-extract-inlines
@@ -171,9 +171,9 @@
                              (car ex-cons) (cdr ex-cons) nil))))))
 
 (ekg-deftest ekg-test-transclude-stability ()
-  (let ((note (ekg-note-create "transcluded" 'org-mode nil)))
+  (let ((note (ekg-note-create :text "transcluded" :mode 'org-mode :tags nil)))
     (ekg-save-note note)
-    (ekg-capture '("tag"))
+    (ekg-capture :tags '("tag"))
     (let ((transclude-txt (format "12%%(transclude-note %S)34 %%(transclude-note %S)"
                                   (ekg-note-id note)
                                   (ekg-note-id note)) ))
@@ -216,7 +216,7 @@
                       (make-ekg-inline :pos 1
                                        :command '(calc "2 ^ 10")
                                        :type 'command))))
-    (let ((note (ekg-note-create "foo bar" 'text-mode nil)))
+    (let ((note (ekg-note-create :text "foo bar" :mode 'text-mode :tags nil)))
       (setf (ekg-note-inlines note) inlines)
       (ekg-save-note note)
       (setq id (ekg-note-id note)))
@@ -231,12 +231,12 @@
       (should (= 0 (length (triples-with-predicate ekg-db 'inline/command)))))))
 
 (ekg-deftest ekg-test-double-transclude-note ()
-  (let ((note (ekg-note-create "transclusion1" 'text-mode nil)))
+  (let ((note (ekg-note-create :text "transclusion1" :mode 'text-mode :tags nil)))
     (ekg-save-note note)
-    (ekg-capture '("test1"))
+    (ekg-capture :tags '("test1"))
     (insert (format "%%(transclude-note %S)" (ekg-note-id note)))
     (ekg-capture-finalize))
-  (ekg-capture '("test2"))
+  (ekg-capture :tags '("test2"))
   (insert (format "%%(transclude-note %S)"
                   (ekg-note-id
                    (car (ekg-get-notes-with-tag "test1")))))
@@ -248,7 +248,7 @@
 (ert-deftest ekg-test-display-note-template ()
   (let ((ekg-display-note-template
          "%n(id)%n(tagged)%n(text 100)%n(other)%n(time-tracked)")
-        (note (ekg-note-create "text" 'text-mode '("tag1" "tag2"))))
+        (note (ekg-note-create :text "text" :mode 'text-mode :tags '("tag1" "tag2"))))
     (setf (ekg-note-properties note) '(:titled/title ("Title")
                                                      :unknown/ignored "unknown"
                                                      :rendered/text "rendered"))
@@ -259,13 +259,13 @@
                           (ekg-display-note note)))))
 
 (ert-deftest ekg-test-note-snippet ()
-  (should (equal "" (ekg-note-snippet (ekg-note-create "" 'text-mode nil))))
-  (should (equal "foo" (ekg-note-snippet (ekg-note-create "foo" 'text-mode nil))))
-  (should (equal "foo…" (ekg-note-snippet (ekg-note-create "foo bar" 'text-mode nil) 3))))
+  (should (equal "" (ekg-note-snippet (ekg-note-create :text "" :mode 'text-mode :tags nil))))
+  (should (equal "foo" (ekg-note-snippet (ekg-note-create :text "foo" :mode 'text-mode :tags nil))))
+  (should (equal "foo…" (ekg-note-snippet (ekg-note-create :text "foo bar" :mode 'text-mode :tags nil) 3))))
 
 (ekg-deftest ekg-test-overlay-interaction-growth ()
   (let ((ekg-capture-auto-tag-funcs nil))
-    (ekg-capture '("test"))
+    (ekg-capture :tags '("test"))
     (let ((o (ekg--metadata-overlay)))
       (should (= (overlay-start o) 1))
       ;; The overlay end is the character just past the end of the visible
@@ -281,7 +281,7 @@
 
 (ekg-deftest ekg-test-overlay-interaction-resist-shrinking ()
   (let ((ekg-capture-auto-tag-funcs nil))
-    (ekg-capture '("test"))
+    (ekg-capture :tags '("test"))
     (let ((o (ekg--metadata-overlay)))
       (should (= (overlay-end o) (+ 1 (length "Tags: test\n"))))
       ;; Go to the end of the overlay, delete the newline, it should be that you


### PR DESCRIPTION
Discussion: https://github.com/ahyatt/ekg/discussions/74
1. Usage of key/val form in parameter improves readability/flexibility.
2. Any essential key that is nil, would be set to default vaule
   1). text: nil --> ""
   2). tags: nil --> (ekg-date-tag), even when ekg-template-tag set nil
   3). mode: nil --> ekg-capture-default-mode
   4). id: --> (ekg--generate-id)