### PR TITLE
Suppress byte-compile warnings

### DIFF
--- a/ekg.el
+++ b/ekg.el
@@ -38,6 +38,10 @@
 (require 'iso8601)
 (require 'url-parse)
 
+(declare-function org-open-at-point "org")
+(declare-function org-redisplay-inline-images "org")
+(declare-function org-activate-links "org")
+
 ;;; Code:
 
 (defgroup ekg nil


### PR DESCRIPTION
```
ekg.el:1493:17: Warning: the function ‘org-activate-links’ is not known to be defined.
ekg.el:1003:10: Warning: the function ‘org-redisplay-inline-images’ is not  known to be defined.
ekg.el:819:55: Warning: the function ‘org-open-at-point’ is not known to be defined.
```