### PR TITLE
Fix tags reversing; ensure listp of `:titled/title` value; support multiple title lines in `ekg-notes-mode`

### DIFF
--- a/ekg-logseq-test.el
+++ b/ekg-logseq-test.el
@@ -109,7 +109,7 @@
   (let ((note (ekg-note-create :text "line1\nline2\n" :mode 'org-mode :tags '("tag1" "tag2" "tag3"))))
     (setf (ekg-note-id note) "http://www.example.com")
     (setf (ekg-note-modified-time note) 123456789)
-    (setf (ekg-note-properties note) '(:titled/title "Title"))
+    (setf (ekg-note-properties note) '(:titled/title ("Title")))
     (should (equal
              "* Title\n:PROPERTIES:\n:ID: http://www.example.com\n:EKG_HASH: c696f3d4b296c737155637d3a708d2b986ab6f6f\n:END:\n#[[tag1]] #[[tag2]]\nhttp://www.example.com\nline1\nline2\n"
              (ekg-logseq-note-to-logseq-org note "tag3")))

--- a/ekg.el
+++ b/ekg.el
@@ -1295,7 +1295,8 @@ If EXPECT-VALID is true, warn when we encounter an unparseable field."
            do
            (pcase (assoc-default field ekg-property-multivalue-type)
              ('line (push value (gethash field values)))
-             ('comma (push (ekg--split-metadata-string value) (gethash field values)))
+             ('comma (mapc (lambda (elt) (push elt (gethash field values)))
+                           (ekg--split-metadata-string value)))
              (_ (setf (gethash field values) value)))
            finally return
            (maphash (lambda (key val)

--- a/ekg.el
+++ b/ekg.el
@@ -1041,8 +1041,7 @@ However, if URL already exists, we edit the existing note on it."
     (if existing
         (ekg-edit (ekg-get-note-with-id url))
       (ekg-capture :tags (list (concat "doc/" (downcase cleaned-title)))
-                   ;; Remove commas from the value.
-                   :properties `(:titled/title ,cleaned-title)
+                   :properties `(:titled/title ,(list title))
                    :id url))))
 
 (defun ekg-capture-file ()
@@ -1058,7 +1057,7 @@ file. If not, an error will be thrown."
       (if existing
           (ekg-edit (ekg-get-note-with-id file))
         (ekg-capture :tags (list (concat "doc/" (downcase (file-name-nondirectory file))))
-                     :properties `(:titled/title ,(file-name-nondirectory file))
+                     :properties `(:titled/title ,(list (file-name-nondirectory file)))
                      :id file)))))
 
 (defun ekg-change-mode (mode)

--- a/ekg.el
+++ b/ekg.el
@@ -695,7 +695,7 @@ FORMAT-STR controls how the time is formatted."
   (if-let (title (plist-get (ekg-note-properties note) :titled/title))
       (propertize (concat
                (mapconcat #'identity (plist-get (ekg-note-properties note) :titled/title)
-                          " / ") "\n")
+                          "\n") "\n")
               'face 'ekg-title)
     ""))
 


### PR DESCRIPTION
This PR is to address:

1. the remaining issue of tags reversing

Before save:
```
Tags: test 1, test 2, test 3, test 4
```

After save and reopen note:
```
Tags: test 4, test 3, test 2, test 1
```

2. Ensure :titled/title value to be a list, to get `ekg-capture-url` & `ekg-capture-file` working again.

3. Display titles at multiple lines in `ekg-notes-mode`.

Related discussion: #110 .