### PR TITLE
Remove extra `list` in `ekg-notes-select-and-browse-url` & Fix typos

### DIFF
--- a/ekg.el
+++ b/ekg.el
@@ -1536,12 +1536,10 @@ TITLE is the title of the URL to browse to."
                 (completing-read
                  "Doc: "
                  (mapcan (lambda (note)
-                           (let ((title
-                                  (plist-get (ekg-note-properties note)
-                                             :titled/title)))
-                             (when title (list title))))
+                           (plist-get (ekg-note-properties note)
+                                      :titled/title))
                          (ewoc-collect ekg-notes-ewoc #'identity)))) ekg-notes-mode)
-  (ekg-browse-url title))
+  (when title (ekg-browse-url title)))
 
 (defun ekg--show-notes (name notes-func tags)
   "Display notes from NOTES-FUNC in buffer.

--- a/ekg.el
+++ b/ekg.el
@@ -923,11 +923,11 @@ The ID represents meaningful resource to the user, other than auto-generated id.
             (overlays-in (point-min) (point-max))))
       (make-overlay (point-min) (point-max) nil nil t)))
 
-(defun ekg--metadata-on-insert-behind (_ after begin-mod eng-mod &optional _)
+(defun ekg--metadata-on-insert-behind (_ after begin-mod end-mod &optional _)
   "Make sure nothing is inserted behind the metadata overlay.
 Also make sure we always have a line with which the user can add text."
   (when after
-    (delete-region begin-mod eng-mod)
+    (delete-region begin-mod end-mod)
     (when (= (point) (point-max))
       (insert "\n"))))
 


### PR DESCRIPTION
Hello @ahyatt,

1. For `ekg-notes-select-and-browse-url`, since title in the let-binding is a list already, no need to wrap it with (list ...). Otherwise, only ONE title in notes with multi-titles will be collected.
2. Typos in `ekg--metadata-on-insert-behind`