### PR TITLE
Add ekg-capture/edit-abort function

### DIFF
--- a/README.org
+++ b/README.org
@@ -187,12 +187,14 @@ Commands relevant to capture buffers:
 |------------------------+--------------------------------------|
 | =ekg-change-mode=      | Change note major-mode               |
 | =ekg-capture-finalize= | Finish and save (bound to =C-c C-c=) |
+| =ekg-capture-abort=    | Trash the note  (bound to =C-c C-k=) |
 
 Commands relevant to edit buffers:
 
 | Command             | Description                          |
 |---------------------+--------------------------------------|
 | =ekg-change-mode=   | Change note major-mode               |
+| =ekg-edit-abort=    | Abort all edits (bound to =C-c C-k=) |
 | =ekg-edit-finalize= | Finish and save (bound to =C-c C-c=) |
 
 Commands relevant to note view buffers:

--- a/ekg-auto-save.el
+++ b/ekg-auto-save.el
@@ -178,17 +178,10 @@ After save, reset idle timer and keystroke counter."
     (ekg-auto-save-initialize-idle-timer)
     (setq ekg-auto-save-keystroke-counter 0)))
 
-(defun ekg-auto-save-on-buffer-kill ()
-  "Save everything unconditionally on buffer kill.
-Additionally, do some cleanup, limiting their effect to
-`ekg-capture-mode' and `ekg-edit-mode' only."
-  (when (and (or ekg-edit-mode ekg-capture-mode)
-             (buffer-modified-p))
-    (if ekg-capture-mode
-        (ekg-save-draft)
-      (ekg-edit-save)))
-  ;; Cleanup: cancel idle timer, keystroke counter, remove advices on
-  ;; commands when there's no editable ekg buffer
+(defun ekg-auto-save-cleanup-on-buffer-kill ()
+  "Do some cleanup on buffer kill.
+Cancel buffer related idle timer, keystroke counter; remove
+advices on commands when there's no editable ekg buffer."
   (ekg-auto-save-stop-idle-timer)
   (remove-hook 'post-self-insert-hook #'ekg-auto-save-after-some-keystrokes t)
   (unless (seq-some
@@ -213,7 +206,7 @@ Additionally, do some cleanup, limiting their effect to
   (dolist (hook ekg-auto-save-hook-triggers)
     (add-hook hook #'ekg-auto-save-func nil t))
   (ekg-auto-save-advice-trigger-commands)
-  (add-hook 'kill-buffer-hook #'ekg-auto-save-on-buffer-kill nil t))
+  (add-hook 'kill-buffer-hook #'ekg-auto-save-cleanup-on-buffer-kill nil t))
 
 (defun ekg-auto-save-stop ()
   "Cleanup advices, hooks, timers and keystroke counter."
@@ -222,7 +215,7 @@ Additionally, do some cleanup, limiting their effect to
   (dolist (hook ekg-auto-save-hook-triggers)
     (remove-hook hook #'ekg-auto-save-func t))
   (ekg-auto-save-remove-advice-from-trigger-commands)
-  (remove-hook 'kill-buffer-hook #'ekg-auto-save-on-buffer-kill t))
+  (remove-hook 'kill-buffer-hook #'ekg-auto-save-cleanup-on-buffer-kill t))
 
 ;;;###autoload
 (define-minor-mode ekg-auto-save-mode

--- a/ekg-auto-save.el
+++ b/ekg-auto-save.el
@@ -164,7 +164,7 @@ After save, reset idle timer and keystroke counter."
              (buffer-modified-p)
              ;; avoid creating immature tags from unfinished tags
              (not (ekg--in-metadata-p))
-             (not (minibufferp))
+             (not cursor-in-echo-area)
              (not (or (use-region-p) (secondary-selection-exist-p)))
              (not (or defining-kbd-macro executing-kbd-macro))
              (or (not (functionp ekg-auto-save-predicate))

--- a/ekg.el
+++ b/ekg.el
@@ -1370,7 +1370,9 @@ Discarded notes will be moved to trash."
   (interactive nil ekg-capture-mode)
   (ekg-connect)
   (when (y-or-n-p "Are you sure to abort this capture?")
-    (ekg-note-trash ekg-note)
+    (let ((id (ekg-note-id ekg-note)))
+      (when (ekg-note-with-id-exists-p id)
+        (ekg-note-delete-by-id id)))
     (kill-buffer)))
 
 (defun ekg-tag-trash-p (tag)

--- a/ekg.el
+++ b/ekg.el
@@ -795,17 +795,19 @@ not supplied, we use a default of 10."
             (if (> (length (ekg-note-text note)) display-length) "…" ""))))
 
 (defun ekg-kill-buffer-query-function ()
-  "Action to take for unsaved ekg editable buffer on buffer kill."
+  "Action to take for unsaved ekg editable buffer on buffer kill.
+If final result returns t, the buffer will be killed. If it
+returns nil, the buffer will leave open."
   (cl-flet ((save-fn ()
               (if ekg-capture-mode
                   (ekg-save-draft)
-                (ekg-edit-save) t))
+                (ekg-edit-save)) t)
             (abort-all-fn ()
               (if ekg-capture-mode
                   (let ((id (ekg-note-id ekg-note)))
                     (when (ekg-note-with-id-exists-p id)
                       (ekg-note-delete-by-id id)))
-                (ekg-save-note ekg-note-orig-note) t))
+                (ekg-save-note ekg-note-orig-note)) t)
             (response-fn ()
               (cadr (read-multiple-choice
                      "Buffer modified; kill anyway?"

--- a/ekg.el
+++ b/ekg.el
@@ -1319,7 +1319,7 @@ Argument FINISHED is non-nil if the user has chosen a completion."
 (defun ekg-edit-abort ()
   "Abort the current edit, restore to its orignial state."
   (interactive nil ekg-edit-mode)
-  (when (y-or-n-p "Are you sure to abort all the edits?")
+  (when (y-or-n-p "Are you sure you want to abort all the edits?")
     (ekg-save-note ekg-note-orig-note)
     (setq-local kill-buffer-query-functions
                 (delq 'ekg-kill-buffer-query-function
@@ -1397,7 +1397,7 @@ If EXPECT-VALID is true, warn when we encounter an unparseable field."
 Discarded notes will be moved to trash."
   (interactive nil ekg-capture-mode)
   (ekg-connect)
-  (when (y-or-n-p "Are you sure to abort this capture?")
+  (when (y-or-n-p "Are you sure you want to abort this capture?")
     (let ((id (ekg-note-id ekg-note)))
       (when (ekg-note-with-id-exists-p id)
         (ekg-note-delete-by-id id)))
@@ -1593,7 +1593,7 @@ current note without a prompt."
   (interactive "P" ekg-notes-mode)
   (let ((note (ekg-current-note-or-error))
         (inhibit-read-only t))
-    (when (or arg (y-or-n-p "Are you sure to delete this note?"))
+    (when (or arg (y-or-n-p "Are you sure you want to delete this note?"))
       (ekg-note-trash note)
       (ewoc-delete ekg-notes-ewoc (ewoc-locate ekg-notes-ewoc))
       (ekg--note-highlight))))

--- a/ekg.el
+++ b/ekg.el
@@ -142,6 +142,14 @@ not in the template."
   :type 'boolean
   :group 'ekg)
 
+(defcustom ekg-save-action-on-buffer-kill 'query
+  "Action to take for unsaved ekg editable buffer on buffer kill."
+  :type '(choice (const :tag "Ask before killing" query)
+                 (const :tag "Abort unsaved changes" abort-unsaved)
+                 (const :tag "Abort this capture or all edits" abort-all)
+                 (const :tag "Save note" save))
+  :group 'ekg)
+
 (defconst ekg-db-file-obsolete (file-name-concat user-emacs-directory "ekg.db")
   "The original database name that ekg started with.")
 
@@ -778,33 +786,41 @@ not supplied, we use a default of 10."
     (format "%s%s" (substring-no-properties (ekg-note-text note) 0 display-length)
             (if (> (length (ekg-note-text note)) display-length) "…" ""))))
 
-(defun ekg-kill-buffer--possibly-save (buf)
-  "Ask the user to confirm killing of a modified BUF.
-Adapted from `kill-buffer--possibly-save'."
-  (let ((response
-         (cadr
-          (read-multiple-choice
-           (format "Buffer %s modified; kill anyway?" (buffer-name))
-           '((?y "yes" "kill buffer without saving")
-             (?n "no" "exit without doing anything")
-             (?s "save and then kill" "save the buffer and then kill it"))
-           nil nil (and (not use-short-answers)
-                        (not (use-dialog-box-p)))))))
-    (if (equal response "no")
-        nil
-      (unless (equal response "yes")
-        (with-current-buffer buf
-          (if ekg-capture-mode
-              (ekg-save-draft)
-            (ekg-edit-save))))
-      t)))
-
 (defun ekg-kill-buffer-query-function ()
-  "Ask before killing an unsaved ekg editable buffer."
-  (if (and (or ekg-capture-mode ekg-edit-mode)
-           (buffer-modified-p))
-      (ekg-kill-buffer--possibly-save (current-buffer))
-    t))
+  "Action to take for unsaved ekg editable buffer on buffer kill."
+  (cl-flet ((save-fn ()
+              (if ekg-capture-mode
+                  (ekg-save-draft)
+                (ekg-edit-save) t))
+            (abort-all-fn ()
+              (if ekg-capture-mode
+                  (let ((id (ekg-note-id ekg-note)))
+                    (when (ekg-note-with-id-exists-p id)
+                      (ekg-note-delete-by-id id)))
+                (ekg-save-note ekg-note-orig-note) t))
+            (response-fn ()
+              (cadr (read-multiple-choice
+                     "Buffer modified; kill anyway?"
+                     `((?y "yes//abort-unsaved" "abort unsaved changes")
+                       (?Y "Yes//abort-all" ,(if ekg-capture-mode
+                                                 "abort this capture"
+                                               "abort all edits"))
+                       (?s "yes//save" "save note and then kill it")
+                       (?n "no" "exit without doing anything"))
+                     nil nil (and (not use-short-answers)
+                                  (not (use-dialog-box-p)))))))
+    (if (and (or ekg-capture-mode ekg-edit-mode)
+             (buffer-modified-p))
+        (pcase ekg-save-action-on-buffer-kill
+          ('abort-unsaved t)
+          ('abort-all (abort-all-fn))
+          ('save (save-fn))
+          ('query (pcase (response-fn)
+                    ("yes//abort-unsaved" t)
+                    ("Yes//abort-all" (abort-all-fn))
+                    ("yes//save" (save-fn))
+                    ("no" nil))))
+      t)))
 
 (defun ekg-header-line-format ()
   "Header line format for the ekg capture or edit buffer."

--- a/ekg.el
+++ b/ekg.el
@@ -848,9 +848,6 @@ This is used when capturing new notes.")
   :interactive nil
   (when ekg-capture-mode (ekg-set-local-variables)))
 
-(defvar ekg-capture-mode-hook nil
-  "Hook for `ekg-capture-mode'.")
-
 (defvar ekg-edit-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map "\C-c\C-c" #'ekg-edit-finalize)
@@ -866,9 +863,6 @@ This is used when editing existing notes.")
   :init-value nil
   :lighter " EKG-ED"
   :interactive nil)
-
-(defvar ekg-edit-mode-hook nil
-  "Hook for `ekg-edit-mode'.")
 
 (defvar-local ekg-note nil
   "Holds the note information for buffers adding or changing notes.")

--- a/ekg.el
+++ b/ekg.el
@@ -806,6 +806,20 @@ Adapted from `kill-buffer--possibly-save'."
       (ekg-kill-buffer--possibly-save (current-buffer))
     t))
 
+(defun ekg-header-line-format ()
+  "Header line format for the ekg capture or edit buffer."
+  (if ekg-capture-mode
+      (substitute-command-keys
+       "\\<ekg-capture-mode-map>Capture buffer. \
+Finish `\\[ekg-capture-finalize]'  \
+Save as draft `\\[ekg-save-draft]'  \
+Abort `\\[ekg-capture-abort]'.")
+    (substitute-command-keys
+     "\\<ekg-edit-mode-map>Edit buffer. \
+Finish `\\[ekg-edit-finalize]'  \
+Save `\\[ekg-edit-save]'  \
+Abort `\\[ekg-edit-abort]'.")))
+
 (defun ekg-set-local-variables ()
   "Set some common local variables."
   (setq-local
@@ -1117,20 +1131,6 @@ file. If not, an error will be thrown."
         (ekg-capture :tags (list (concat "doc/" (downcase (file-name-nondirectory file))))
                      :properties `(:titled/title ,(list (file-name-nondirectory file)))
                      :id file)))))
-
-(defun ekg-header-line-format ()
-  "Header line format for the ekg capture or edit buffer."
-  (if ekg-capture-mode
-      (substitute-command-keys
-       "\\<ekg-capture-mode-map>Capture buffer. \
-Finish `\\[ekg-capture-finalize]'  \
-Save as draft `\\[ekg-save-draft]'  \
-Abort `\\[ekg-capture-abort]'.")
-    (substitute-command-keys
-     "\\<ekg-edit-mode-map>Edit buffer. \
-Finish `\\[ekg-edit-finalize]'  \
-Save `\\[ekg-edit-save]'  \
-Abort `\\[ekg-edit-abort]'.")))
 
 (defun ekg-change-mode (mode)
   "Change the mode of the current note to MODE."

--- a/ekg.el
+++ b/ekg.el
@@ -143,11 +143,19 @@ not in the template."
   :group 'ekg)
 
 (defcustom ekg-save-action-on-buffer-kill 'query
-  "Action to take for unsaved ekg editable buffer on buffer kill."
-  :type '(choice (const :tag "Ask before killing" query)
-                 (const :tag "Abort unsaved changes" abort-unsaved)
-                 (const :tag "Abort this capture or all edits" abort-all)
-                 (const :tag "Save note" save))
+  "Action to take on unsaved ekg editable buffer on buffer kill.
+If value is \\='abort-unsaved, discard the unsaved changes, the
+already saved part will be kept. If value is \\='abort-all, for
+`ekg-capture-mode', the whole capture will be aborted; for
+`ekg-edit-mode', all edits (saved or not) will be discarded, the
+note will be restored to its original state at open. If value is
+\\='save, save the note to db. If value is \\='query, ask the
+user which action to take."
+  :type '(choice
+          (const :tag "Ask before killing" query)
+          (const :tag "Abort unsaved changes (the saved part will be kept)" abort-unsaved)
+          (const :tag "Abort capture in ekg-capture-mode, or abort all edits in ekg-edit-mode" abort-all)
+          (const :tag "Save note" save))
   :group 'ekg)
 
 (defconst ekg-db-file-obsolete (file-name-concat user-emacs-directory "ekg.db")

--- a/ekg.el
+++ b/ekg.el
@@ -820,7 +820,7 @@ Finish `\\[ekg-edit-finalize]'  \
 Save `\\[ekg-edit-save]'  \
 Abort `\\[ekg-edit-abort]'.")))
 
-(defun ekg-set-local-variables ()
+(defun ekg--set-local-variables ()
   "Set some common local variables."
   (setq-local
    completion-at-point-functions
@@ -846,7 +846,7 @@ This is used when capturing new notes.")
   :init-value nil
   :lighter " EKG-CAP"
   :interactive nil
-  (when ekg-capture-mode (ekg-set-local-variables)))
+  (when ekg-capture-mode (ekg--set-local-variables)))
 
 (defvar ekg-edit-mode-map
   (let ((map (make-sparse-keymap)))
@@ -1134,7 +1134,7 @@ file. If not, an error will be thrown."
         (minor-mode (if ekg-capture-mode 'ekg-capture-mode 'ekg-edit-mode)))
     (funcall mode)
     (funcall minor-mode)
-    (ekg-set-local-variables)
+    (ekg--set-local-variables)
     (setq ekg-note note)))
 
 (defun ekg-edit (note)
@@ -1145,7 +1145,7 @@ file. If not, an error will be thrown."
       (when (ekg-note-mode note)
         (funcall (ekg-note-mode note)))
       (ekg-edit-mode 1)
-      (ekg-set-local-variables)
+      (ekg--set-local-variables)
       (setq-local ekg-note (copy-ekg-note note)       ; shallow copy
                   ekg-note-orig-note (copy-tree note) ; deep copy to avoid later change
                   ekg-note-orig-id (ekg-note-id note))

--- a/ekg.el
+++ b/ekg.el
@@ -778,6 +778,34 @@ not supplied, we use a default of 10."
     (format "%s%s" (substring-no-properties (ekg-note-text note) 0 display-length)
             (if (> (length (ekg-note-text note)) display-length) "…" ""))))
 
+(defun ekg-kill-buffer--possibly-save (buf)
+  "Ask the user to confirm killing of a modified BUF.
+Adapted from `kill-buffer--possibly-save'."
+  (let ((response
+         (cadr
+          (read-multiple-choice
+           (format "Buffer %s modified; kill anyway?" (buffer-name))
+           '((?y "yes" "kill buffer without saving")
+             (?n "no" "exit without doing anything")
+             (?s "save and then kill" "save the buffer and then kill it"))
+           nil nil (and (not use-short-answers)
+                        (not (use-dialog-box-p)))))))
+    (if (equal response "no")
+        nil
+      (unless (equal response "yes")
+        (with-current-buffer buf
+          (if ekg-capture-mode
+              (ekg-save-draft)
+            (ekg-edit-save))))
+      t)))
+
+(defun ekg-kill-buffer-query-function ()
+  "Ask before killing an unsaved ekg editable buffer."
+  (if (and (or ekg-capture-mode ekg-edit-mode)
+           (buffer-modified-p))
+      (ekg-kill-buffer--possibly-save (current-buffer))
+    t))
+
 (defvar ekg-capture-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map "\C-c\C-c" #'ekg-capture-finalize)
@@ -797,6 +825,9 @@ This is used when capturing new notes.")
     (setq-local completion-at-point-functions
                 (append (list #'ekg--capf #'ekg--transclude-titled-note-completion)
                         completion-at-point-functions)
+                kill-buffer-query-functions
+                (append (list #'ekg-kill-buffer-query-function)
+                        kill-buffer-query-functions)
                 header-line-format (ekg-header-line-format))))
 
 (defvar ekg-capture-mode-hook nil
@@ -1105,7 +1136,10 @@ Abort `\\[ekg-edit-abort]'.")))
         (minor-mode (if ekg-capture-mode 'ekg-capture-mode 'ekg-edit-mode)))
     (funcall mode)
     (funcall minor-mode)
-    (setq-local header-line-format (ekg-header-line-format))
+    (setq-local header-line-format (ekg-header-line-format)
+                kill-buffer-query-functions
+                (append (list #'ekg-kill-buffer-query-function)
+                        kill-buffer-query-functions))
     (setq ekg-note note)))
 
 (defun ekg-edit (note)
@@ -1120,6 +1154,9 @@ Abort `\\[ekg-edit-abort]'.")))
                   (append (list #'ekg--capf
                                 #'ekg--transclude-titled-note-completion)
                           completion-at-point-functions)
+                  kill-buffer-query-functions
+                  (append (list #'ekg-kill-buffer-query-function)
+                          kill-buffer-query-functions)
                   header-line-format (ekg-header-line-format)
                   ekg-note (copy-ekg-note note)       ; shallow copy
                   ekg-note-orig-note (copy-tree note) ; deep copy to avoid later change
@@ -1296,6 +1333,9 @@ Argument FINISHED is non-nil if the user has chosen a completion."
   (interactive nil ekg-edit-mode)
   (when (y-or-n-p "Are you sure to abort all the edits?")
     (ekg-save-note ekg-note-orig-note)
+    (setq-local kill-buffer-query-functions
+                (delq 'ekg-kill-buffer-query-function
+                      kill-buffer-query-functions))
     (kill-buffer)))
 
 (defun ekg--split-metadata-string (val)
@@ -1373,6 +1413,9 @@ Discarded notes will be moved to trash."
     (let ((id (ekg-note-id ekg-note)))
       (when (ekg-note-with-id-exists-p id)
         (ekg-note-delete-by-id id)))
+    (setq-local kill-buffer-query-functions
+                (delq 'ekg-kill-buffer-query-function
+                      kill-buffer-query-functions))
     (kill-buffer)))
 
 (defun ekg-tag-trash-p (tag)


### PR DESCRIPTION
Why this commit:

I personally want to have an abort function, so that I could decide where the note should go. Even the note has been auto-saved as draft by `ekg-auto-save-mode` (my personal branch), with `ekg-capture-abort`, the note still could go to trash. Or when I edit a note but later I decide not to save it at all, `ekg-edit-abort` could abort all the edits.

Changes in this commit:

1. In `ekg-edit-mode`: abort edit -> restore note to its original state. (Except for modification time: `ekg-save-note` recalculates it finally. Q: Any function to compare the new note vs the note in db: if value are the same, don't update the modification time?)

2. In `ekg-capture-mode`: abort capture -> trashing the note.

3. Clean up some whitespaces and bad indentations around the edits.


This commit also address https://github.com/ahyatt/ekg/pull/19 :

> Do we want C-c C-k to abort the capture process?