### PR TITLE
Don't rely on completion exit, detect completed tags manually

### DIFF
--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -73,6 +73,9 @@ triples library is already installed.
 (require 'ekg)
 #+end_src
 * Changelog
+** Version 0.7.0
+- Use the global keymap in the note metadata region.
+- Run tag hooks when a valid tag is typed, instead of relying on completion, which often doesn't work.
 ** Version 0.6.0
 - Add tag and similar notes to the context when having LLMs add to or replace
   notes.  ~ekg-llm-default-instructions~ replaces the previous variable,
@@ -403,9 +406,11 @@ of tags are also searched, so the same thing will happen if the tag you add is
 long as it exists.
 
 The adding of templates happens whether intially when setting up the capture
-buffer, or later when the user completes a tag.  Tags added without completion
-won't trigger this behavior, since at the moment ekg will not be able to
-understand that a tag has changed.
+buffer, or later when the user types a tag that is a valid tag.  Because of
+this, it's best to avoid adding templates to tags that are prefixes of other
+tags you'd like to use, but don't want the template on, because as soon as ekg
+sees the prefix that's a valid tag being typed, it will trigger that tag's
+templates.
 
 You can choose a tag other than "template" as the trigger for this templating
 behavior, by customizing ~ekg-template-tag~.
@@ -604,8 +609,8 @@ tags, you can enable this tag-based customization.
 This works in a similar manner to [[#templates][templates]], except that a template tag only
 takes effect when you add it, while a magic tag takes effect both when first
 adding it and when editing a note with the tag.  But they also share the same
-shortcoming: you must add the tag via completion to get its effects to run.  (It
-will still take effect when editing the note though.)
+shortcoming: if the tag is a prefix, it will trigger as soon as typed, even if
+you wanted to use a different tag that is prefixed with the tag.
 
 Creating magic tags is also like creating templates.  You create a note and use
 a special tag that indicates this tag is a magic tag.  That special tag is

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -68,6 +68,7 @@ Installation
 
 Changelog
 
+* Version 0.7.0: Version 070. 
 * Version 0.6.0: Version 060. 
 * Version 0.5.1: Version 051. 
 * Version 0.5: Version 05. 
@@ -198,6 +199,7 @@ triples library is already installed.
 @chapter Changelog
 
 @menu
+* Version 0.7.0: Version 070. 
 * Version 0.6.0: Version 060. 
 * Version 0.5.1: Version 051. 
 * Version 0.5: Version 05. 
@@ -212,6 +214,16 @@ triples library is already installed.
 * Version 0.2.1: Version 021. 
 * Version 0.2: Version 02. 
 @end menu
+
+@node Version 070
+@section Version 0.7.0
+
+@itemize
+@item
+Use the global keymap in the note metadata region.
+@item
+Run tag hooks when a valid tag is typed, instead of relying on completion, which often doesn't work.
+@end itemize
 
 @node Version 060
 @section Version 0.6.0
@@ -727,9 +739,11 @@ of tags are also searched, so the same thing will happen if the tag you add is
 long as it exists.
 
 The adding of templates happens whether intially when setting up the capture
-buffer, or later when the user completes a tag.  Tags added without completion
-won't trigger this behavior, since at the moment ekg will not be able to
-understand that a tag has changed.
+buffer, or later when the user types a tag that is a valid tag.  Because of
+this, it's best to avoid adding templates to tags that are prefixes of other
+tags you'd like to use, but don't want the template on, because as soon as ekg
+sees the prefix that's a valid tag being typed, it will trigger that tag's
+templates.
 
 You can choose a tag other than "template" as the trigger for this templating
 behavior, by customizing @code{ekg-template-tag}.
@@ -955,8 +969,8 @@ tags, you can enable this tag-based customization.
 This works in a similar manner to @ref{Templates, , templates}, except that a template tag only
 takes effect when you add it, while a magic tag takes effect both when first
 adding it and when editing a note with the tag.  But they also share the same
-shortcoming: you must add the tag via completion to get its effects to run.  (It
-will still take effect when editing the note though.)
+shortcoming: if the tag is a prefix, it will trigger as soon as typed, even if
+you wanted to use a different tag that is prefixed with the tag.
 
 Creating magic tags is also like creating templates.  You create a note and use
 a special tag that indicates this tag is a magic tag.  That special tag is

--- a/ekg-test.el
+++ b/ekg-test.el
@@ -132,6 +132,17 @@
       (should (string-match (rx (literal "ABC")) text))
       (should (string-match (rx (literal "DEF")) text)))))
 
+(ekg-deftest ekg-test-template-completion ()
+  (ekg-save-note (ekg-note-create :text "ABC" :mode #'text-mode :tags '("test" "template")))
+  (let ((ekg-note-add-tag-hook '(ekg-on-add-tag-insert-template)))
+    (ekg-capture)
+    (goto-char (point-min))
+    (end-of-line)
+    (insert ", tes")
+    (ert-simulate-command '(completion-at-point)))
+  (should (string-match (rx (literal "ABC")) (substring-no-properties (buffer-string))))
+  (kill-buffer))
+
 (ekg-deftest ekg-test-get-notes-with-tags ()
   (ekg-save-note (ekg-note-create :text "ABC" :mode #'text-mode :tags '("foo" "bar")))
   (should-not (ekg-get-notes-with-tags '("foo" "none")))

--- a/ekg-test.el
+++ b/ekg-test.el
@@ -334,6 +334,8 @@
       (cl-loop for i from 1 to 10
                do
                (ekg-capture)
+               ;; Necessary to reproduce the original issue with markdown-mode.
+               (font-lock-ensure)
                (goto-char i)
                (cond
                 ((= i 1)

--- a/ekg-test.el
+++ b/ekg-test.el
@@ -334,9 +334,6 @@
       (cl-loop for i from 1 to 10
                do
                (ekg-capture)
-               ;; TODO(ahyatt) Find out why this is necessary to reproduce bad
-               ;; behavior.
-               (funcall mode)
                (goto-char i)
                (cond
                 ((= i 1)

--- a/ekg.el
+++ b/ekg.el
@@ -904,6 +904,19 @@ ARG is the prefix argument, if used it opens in another window."
                                    (markdown-wiki-link-link))))
     (markdown-follow-thing-at-point arg)))
 
+(defun ekg-detect-tag-completion ()
+  "After a modification, check if the user has completed a tag.
+If so, call the necessary hooks."
+  (let ((field (ekg--metadata-current-field)))
+    (when (equal "Tags" (car field))
+      (let ((current-tags (ekg-note-tags ekg-note))
+            (maybe-tag (car (last (string-split (cdr field))))))
+        (when (and (not (member maybe-tag current-tags))
+                   (member maybe-tag (ekg-tags)))
+          (ekg--update-from-metadata)
+          (run-hook-with-args 'ekg-note-add-tag-hook maybe-tag)
+          (ekg-maybe-function-tag maybe-tag))))))
+
 (defun ekg--set-local-variables ()
   "Set some common local variables."
   (setq-local
@@ -917,6 +930,7 @@ ARG is the prefix argument, if used it opens in another window."
    header-line-format (ekg--header-line-format))
   (add-hook 'pre-command-hook #'ekg-narrow-for-command nil t)
   (add-hook 'post-command-hook #'ekg-unnarrow-for-command nil t)
+
   (when (eq major-mode 'markdown-mode)
     (setq-local markdown-enable-wiki-links t
                 markdown-wiki-link-fontify-missing nil)
@@ -1309,6 +1323,7 @@ after the modification.
   3) The user can't delete the metadata - if the user tries to
 delete from the end of the metadata, we need to fix it back up."
   (when after
+    (ekg-detect-tag-completion)
     ;; If we're at the end of the metadata, we need to make sure we don't delete
     ;; it from the previous line. Moving after is also suspicious, because we
     ;; don't know where to move it. It's easiest and clearest if we just do
@@ -1362,6 +1377,7 @@ delete from the end of the metadata, we need to fix it back up."
     (overlay-put o 'modification-hooks '(ekg--metadata-modification))
     (overlay-put o 'insert-behind-hooks '(ekg--metadata-on-insert-behind))
     (overlay-put o 'face 'ekg-metadata)
+    (overlay-put o 'local-map global-map)
     (buffer-enable-undo)
     ;; If org-mode is on, the metadata messes up the org-element-cache, so let's disable it.
     (when (eq major-mode 'org-mode)
@@ -1559,20 +1575,6 @@ attempt the completion."
         :exclusive t :exit-function (lambda (_completion finished)
                                       (when finished (insert ": ")))))
 
-(defun ekg--tags-cap-exit (completion finished)
-  "Cleanup after completion at point happened in a tag.
-The cleanup now is just to always have a space after every comma.
-Argument COMPLETION is the chosen completion.
-Argument FINISHED is non-nil if the user has chosen a completion."
-  (when finished
-    (save-excursion
-      (when (search-backward (format ",%s" completion) (line-beginning-position) t)
-        (replace-match (format ", %s" completion)))
-      (when (search-backward (format ":%s" completion) (line-beginning-position) t)
-        (replace-match (format ": %s" completion)))
-      (run-hook-with-args 'ekg-note-add-tag-hook completion)
-      (ekg-maybe-function-tag completion))))
-
 (defun ekg--tags-complete ()
   "Completion function for tags, CAPF-style."
   (let ((end (save-excursion
@@ -1585,9 +1587,8 @@ Argument FINISHED is non-nil if the user has chosen a completion."
                  (point))))
     (list start end (completion-table-dynamic
                      (lambda (_)
-                       (ekg--update-from-metadata)
                        (seq-difference (ekg-tags) (ekg-note-tags ekg-note))))
-          :exclusive t :exit-function #'ekg--tags-cap-exit)))
+          :exclusive t)))
 
 (defun ekg-save-draft ()
   "Save the current note as a draft."

--- a/ekg.el
+++ b/ekg.el
@@ -904,19 +904,6 @@ ARG is the prefix argument, if used it opens in another window."
                                    (markdown-wiki-link-link))))
     (markdown-follow-thing-at-point arg)))
 
-(defun ekg-detect-tag-completion ()
-  "After a modification, check if the user has completed a tag.
-If so, call the necessary hooks."
-  (let ((field (ekg--metadata-current-field)))
-    (when (equal "Tags" (car field))
-      (let ((current-tags (ekg-note-tags ekg-note))
-            (maybe-tag (car (last (string-split (cdr field))))))
-        (when (and (not (member maybe-tag current-tags))
-                   (member maybe-tag (ekg-tags)))
-          (ekg--update-from-metadata)
-          (run-hook-with-args 'ekg-note-add-tag-hook maybe-tag)
-          (ekg-maybe-function-tag maybe-tag))))))
-
 (defun ekg--set-local-variables ()
   "Set some common local variables."
   (setq-local
@@ -1589,6 +1576,19 @@ attempt the completion."
                      (lambda (_)
                        (seq-difference (ekg-tags) (ekg-note-tags ekg-note))))
           :exclusive t)))
+
+(defun ekg-detect-tag-completion ()
+  "After a modification, check if the user has completed a tag.
+If so, call the necessary hooks."
+  (let ((field (ekg--metadata-current-field)))
+    (when (equal "Tags" (car field))
+      (let ((current-tags (ekg-note-tags ekg-note))
+            (maybe-tag (car (last (split-string (cdr field))))))
+        (when (and (not (member maybe-tag current-tags))
+                   (member maybe-tag (ekg-tags)))
+          (ekg--update-from-metadata)
+          (run-hook-with-args 'ekg-note-add-tag-hook maybe-tag)
+          (ekg-maybe-function-tag maybe-tag))))))
 
 (defun ekg-save-draft ()
   "Save the current note as a draft."


### PR DESCRIPTION
This fixes behavior on markdown-mode, and makes tag behavior in the metadata work with typing as well as completion.