### PR TITLE
denote-export: linting and test failures

### DIFF
--- a/ekg-denote-test.el
+++ b/ekg-denote-test.el
@@ -126,20 +126,20 @@
     (should (equal denote (ekg-denote-create note)))))
 
 
-(defun ekg-denote-test--matching-denote (regexp)
+(defun ekg-test--matching-denote (regexp)
   "Get denote file name containing REGEXP.
 Enforces single match."
   (let ((files (seq-filter (lambda (x) (string-match-p regexp x))
-			   (denote-directory-text-only-files))))
+			   (denote-directory-files nil nil :text-only))))
     (when files (car files))))
 
-(defun ekg-denote-test--denote-text (file)
+(defun ekg-test--denote-text (file)
   "Get text from denote FILE."
   (with-temp-buffer
     (insert-file-contents file)
     (buffer-string)))
 
-(defun ekg-denote-test--creation-time-from-denote-file (file)
+(defun ekg-test--creation-time-from-denote-file (file)
   "Return creation time for the denote FILE."
   (time-convert
    (encode-time
@@ -147,7 +147,7 @@ Enforces single match."
      (denote-retrieve-filename-identifier file)))
    'integer))
 
-(defun ekg-denote-test--denote-ekg (file)
+(defun ekg-test--denote-ekg (file)
   "Return ekg note for given denote FILE."
   (let* ((creation-time (ekg-test--creation-time-from-denote-file file))
 	 (triples (triples-db-select-pred-op ekg-db :time-tracked/creation-time '= creation-time)))

--- a/ekg-denote-test.el
+++ b/ekg-denote-test.el
@@ -126,21 +126,20 @@
     (should (equal denote (ekg-denote-create note)))))
 
 
-(defun ekg-test--matching-denote (regexp)
+(defun ekg-denote-test--matching-denote (regexp)
   "Get denote file name containing REGEXP.
-
 Enforces single match."
   (let ((files (seq-filter (lambda (x) (string-match-p regexp x))
 			   (denote-directory-text-only-files))))
     (when files (car files))))
 
-(defun ekg-test--denote-text (file)
+(defun ekg-denote-test--denote-text (file)
   "Get text from denote FILE."
   (with-temp-buffer
     (insert-file-contents file)
     (buffer-string)))
 
-(defun ekg-test--creation-time-from-denote-file (file)
+(defun ekg-denote-test--creation-time-from-denote-file (file)
   "Return creation time for the denote FILE."
   (time-convert
    (encode-time
@@ -148,14 +147,14 @@ Enforces single match."
      (denote-retrieve-filename-identifier file)))
    'integer))
 
-(defun ekg-test--denote-ekg (file)
+(defun ekg-denote-test--denote-ekg (file)
   "Return ekg note for given denote FILE."
   (let* ((creation-time (ekg-test--creation-time-from-denote-file file))
 	 (triples (triples-db-select-pred-op ekg-db :time-tracked/creation-time '= creation-time)))
     (should (length= triples 1))
     (ekg-get-note-with-id (car (car triples)))))
 
-(ekg-deftest ekg-test-export ()
+(ekg-deftest ekg-denote-test-export ()
   "Verify export."
   (let ((denote-directory (make-temp-file "denote" t)))
     ;; ekg note creations are exported

--- a/ekg-denote.el
+++ b/ekg-denote.el
@@ -140,8 +140,7 @@ COMBINED-LENGTH."
 
 (defun ekg-denote--rename-if-path-changed (denote)
   "Rename given DENOTE if path has changed.
-Path can change due to title or tag changes.
-"
+Path can change due to title or tag changes."
   (let* ((id (ekg-denote-id denote))
 	 (path (ekg-denote-path denote))
 	 (existing-path (denote-get-path-by-id id)))
@@ -150,7 +149,6 @@ Path can change due to title or tag changes.
 
 (defun ekg-denote--text-save (denote)
   "Save the text from given DENOTE to the disk.
-
 Optionally add front-matter."
   (let ((path (ekg-denote-path denote))
 	(text (ekg-denote-text denote))

--- a/ekg-denote.el
+++ b/ekg-denote.el
@@ -118,7 +118,7 @@ COMBINED-LENGTH."
 	 (ekg-title (plist-get (ekg-note-properties note) :titled/title))
 	 (ekg-title (if (listp ekg-title) (car ekg-title) ekg-title))
 	 (ekg-title (or ekg-title ""))
-	 (title (string-limit (denote-sluggify ekg-title) ekg-denote-export-title-max-len))
+	 (title (string-limit (denote-sluggify 'title ekg-title) ekg-denote-export-title-max-len))
 	 (signature-slug "")
 	 (path (denote-format-file-name (file-name-as-directory denote-directory) id kws title ext signature-slug)))
     (make-ekg-denote :id id

--- a/ekg-denote.el
+++ b/ekg-denote.el
@@ -18,13 +18,13 @@
 ;;; Commentary:
 ;; This package provides integration between ekg and denote.
 ;;
-;; During export, for each ekg note, a denote file is created. Denote
+;; During export, for each ekg note, a denote file is created.  Denote
 ;; does not allow creation time for two notes within a second whereas
 ;; ekg has no such restriction, so it is necessary to ensure that each
 ;; ekg note has a unique creation time for export.  Additionally,
 ;; denote embeds the title and tags in the filename, which is limited
-;; based on the underlying operating system. The titles and tags of
-;; ekg notes are trimmed to a configurable length before export. Ekg
+;; based on the underlying operating system.  The titles and tags of
+;; ekg notes are trimmed to a configurable length before export.  Ekg
 ;; notes can have creation time within a second when trying to bulk
 ;; import org-roam files to ekg.
 ;;
@@ -34,6 +34,8 @@
 (require 'denote)
 (require 'triples)
 (require 'seq)
+
+;;; Code:
 
 (defcustom ekg-denote-export-title-max-len 50
   "Maximum length of the title to trim to during export."
@@ -92,8 +94,9 @@ You can choose not to backup in case denotes are already backed up using git or 
     (remove nil notes)))
 
 (defun ekg-denote-sublist-keywords (kws combined-length)
-  "Return the sublist for the given KWS list such that the
-length of combined KWS is not more than the given COMBINED-LENGTH."
+  "Return the sublist for the given KWS list.
+The length of combined KWS is not more than the given
+COMBINED-LENGTH."
   (if (length< (denote-keywords-combine kws) combined-length) kws
     (ekg-denote-sublist-keywords (butlast kws) combined-length)))
 
@@ -137,7 +140,6 @@ length of combined KWS is not more than the given COMBINED-LENGTH."
 
 (defun ekg-denote--rename-if-path-changed (denote)
   "Rename given DENOTE if path has changed.
-
 Path can change due to title or tag changes.
 "
   (let* ((id (ekg-denote-id denote))
@@ -159,7 +161,7 @@ Optionally add front-matter."
       (denote-add-front-matter path title kws))))
 
 (defun ekg-denote--modified-time-from-file (denote)
-  "Return modified time for the DENOTE"
+  "Return modified time for the DENOTE."
   (let ((path (ekg-denote-path denote)))
     (when (file-exists-p path)
       (time-convert
@@ -189,7 +191,7 @@ Denote uses creation-time as ID."
 Denote uses creation-time as ID and assume it to be unique."
   (let ((creation-times (mapcar #'ekg-note-creation-time notes)))
     (when (not (equal creation-times (seq-uniq creation-times)))
-      (error "ekg-denote: Notes using same creation time."))))
+      (error "ekg-denote: Notes using same creation time"))))
 
 (defun ekg-denote-export ()
   "Export the current ekg database to denote."


### PR DESCRIPTION
Updated the documentation string to fix following linting errors (see during code checkin pipeline execution)

```
[00:00.082]  Linting file ‘ekg-denote.el’
[00:00.094]  ekg-denote.el:38: You should have a section marked ";;; Code:"
[00:00.094]  ekg-denote.el:26: There should be two spaces after a period
[00:00.094]  ekg-denote.el:27: There should be two spaces after a period
[00:00.095]  ekg-denote.el:21: There should be two spaces after a period
[00:00.097]  ekg-denote.el:95: First line is not a complete sentence
[00:00.098]  ekg-denote.el:141: Documentation strings should not start or end with whitespace
[00:00.099]  ekg-denote.el:162: First sentence should end with punctuation
[00:00.101]  ekg-denote.el:192: Error messages should *not* end with a period
[00:00.102]  Found 8 warnings in file ‘ekg-denote.el’
```