### PR TITLE
When showing ekg notes, open the notes in the current window

### DIFF
--- a/ekg.el
+++ b/ekg.el
@@ -2016,7 +2016,7 @@ notes are created with additional tags TAGS."
   (let ((buf (get-buffer-create (format "*ekg %s*" name))))
     (set-buffer buf)
     (ekg--show-notes name notes-func tags)
-    (pop-to-buffer buf)))
+    (switch-to-buffer buf)))
 
 (defun ekg-sort-by-creation-time (a b)
   "Used to pass to `sort', which will supply A and B."


### PR DESCRIPTION
This is different than what is done now, which is to show it in another window (making a new window if necessary).

This will fix https://github.com/ahyatt/ekg/issues/160