### PR TITLE
Improve the LLM json representation of past notes for LLM context

### DIFF
--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -77,6 +77,7 @@ triples library is already installed.
 - Fix issue in trying to get a single-valued item to show up in the metadata line.
 - Fix issue with tag completions triggering incorrectly if they contained spaces.
 - Fix error when displaying unknown schema.
+- Improve JSONification of notes when sending context to LLMs.
 ** Version 0.6.2
 - Add export to [[https://github.com/protesilaos/denote][denote]] (by [[https://github.com/jayrajput][Jay Rajput]])
 ** Version 0.6.1

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -230,6 +230,8 @@ Fix issue in trying to get a single-valued item to show up in the metadata line.
 Fix issue with tag completions triggering incorrectly if they contained spaces.
 @item
 Fix error when displaying unknown schema.
+@item
+Improve JSONification of notes when sending context to LLMs.
 @end itemize
 
 @node Version 062

--- a/ekg-llm-test.el
+++ b/ekg-llm-test.el
@@ -44,6 +44,28 @@
       (should (equal "BEGIN\nvery different text\nEND\n"
                      (substring-no-properties (buffer-string)))))))
 
+(ert-deftest ekg-llm-test-note-to-text ()
+  (let* ((time (current-time))
+         (time-str (format-time-string "%Y-%m-%dT%H:%M:%S" time))
+         (json-encoding-pretty-print t))
+    (should (equal
+             (json-encode
+              (sort
+               `(("tags" . ["tag1" "tag2"])
+                 ("created" . ,time-str)
+                 ("modified" . ,time-str)
+                 ("title" . ["Title"])
+                 ("text" . "Content")
+                 ("id" . "http://example.com/1"))
+               (lambda (a b) (string< (car a) (car b)))))
+             (ekg-llm-note-to-text
+              (make-ekg-note :id "http://example.com/1"
+                             :properties '(:titled/title ("Title"))
+                             :text "Content"
+                             :creation-time time
+                             :modified-time time
+                             :tags '("tag1" "tag2")))))))
+
 (provide 'ekg-llm-test)
 
 ;;; ekg-llm-test.el ends here


### PR DESCRIPTION
Add ID to the JSON, if interesting.

Add any properties that have a label defined.

Remove some duplication of the properties.

Sort to get stable JSON (really just needed for tests).

Add a test for the JSONification.