### PR TITLE
`ekg-setup-notes-buffer' `setq-local' `default-directory' to `ekg-db-file' parent directory.

### DIFF
--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -77,6 +77,7 @@ triples library is already installed.
 - Fix display of extended structured data in notes.
 - Add contrib directory and =ekg-email= as a contribution to import emails to notes in a structured way.
 - Fix inlines not expanding in the contextual notes in =ekg-llm=.
+- Set =default-directory= to db location in notes buffers (by [[https://github.com/monkpearman][S Pearman]]).
 ** Version 0.6.3
 - Fix issue in trying to get a single-valued item to show up in the metadata line.
 - Remove the never-used named, email, and person schema.

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -233,6 +233,8 @@ Fix display of extended structured data in notes.
 Add contrib directory and @samp{ekg-email} as a contribution to import emails to notes in a structured way.
 @item
 Fix inlines not expanding in the contextual notes in @samp{ekg-llm}.
+@item
+Set @samp{default-directory} to db location in notes buffers (by @uref{https://github.com/monkpearman, S Pearman}).
 @end itemize
 
 @node Version 063

--- a/ekg.el
+++ b/ekg.el
@@ -2113,7 +2113,9 @@ notes are created with additional tags TAGS."
 ;;;###autoload
 (defun ekg-show-notes-with-tag (tag)
   "Show notes that contain TAG."
-  (interactive (list (completing-read "Tag: " (ekg-tags))))
+  (interactive (list (ekg-tags-complete 
+                      :prompt "Tag: " 
+                      :collection (ekg-tags))))
   (ekg-setup-notes-buffer
    (format "tag: %s" (ekg-tags-display (list tag)))
    (lambda () (sort (ekg-get-notes-with-tag tag) #'ekg-sort-by-creation-time))

--- a/ekg.el
+++ b/ekg.el
@@ -190,25 +190,6 @@ links out of them, as well as adding them to the note text."
   :type '(repeat string)
   :group 'ekg)
 
-(defcustom ekg-tags-complete-function 'completing-read ; 'completing-read-default
-  "Completion function for use with `ekg-tags-complete'.
-The function should accept the following 8 arguments as per `completing-read':
-
- PROMPT COLLECTION PREDICATE REQUIRE-MATCH
- INITIAL-INPUT HIST DEF INHERIT-INPUT-METHOD"
-  :type 'function
-  :group 'ekg)
-
-(defcustom ekg-tags-complete-multiple-function 'completing-read-multiple
-  "Completion function for use with `ekg-tags-complete-multiple'.
-Default value is `completing-read-multiple', which see.
-The function should accept the following 8 arguments as per `completing-read':
-
- PROMPT COLLECTION PREDICATE REQUIRE-MATCH
- INITIAL-INPUT HIST DEF INHERIT-INPUT-METHOD"
-  :type 'function
-  :group 'ekg)
-
 (defconst ekg-db-file-obsolete (file-name-concat user-emacs-directory "ekg.db")
   "The original database name that ekg started with.")
 
@@ -853,10 +834,8 @@ Returns the ID of the note."
                                      (ekg-document-titles)))
              (selected-title (completing-read "Title: " title-id-pairs nil t)))
         (cdr (assoc selected-title title-id-pairs)))
-    (let* ((notes (ekg-get-notes-with-tag (ekg-tags-complete
-                                           :prompt "Tag: "
-                                           :collection (ekg-tags)
-                                           :require-match t)))
+    (let* ((notes (ekg-get-notes-with-tag
+                   (completing-read "Tag: " (ekg-tags) nil t)))
            (completion-pairs (mapcar
                               (lambda (note)
                                 (cons (ekg-display-note-text note 10)
@@ -1786,14 +1765,8 @@ executing a write if there is a problem."
 This can be done whether TO-TAG already exists or not.  This
 renames all instances of the tag globally, and all notes with
 FROM-TAG will use TO-TAG."
-  (interactive (list (ekg-tags-complete
-                      :prompt "From tag: "
-                      :collection (ekg-tags)
-                      :require-match t)
-                     (ekg--normalize-tag
-                      (ekg-tags-complete
-                       :prompt "To tag: "
-                       :collection (ekg-tags)))))
+  (interactive (list (completing-read "From tag: " (ekg-tags) nil t)
+                     (ekg--normalize-tag (completing-read "To tag: " (ekg-tags)))))
   (ekg-connect)
   (triples-with-transaction
     ekg-db
@@ -1895,9 +1868,7 @@ Raise an error if there is no current note."
   "Show notes associated with TAG.
 If TAG is nil, it will be read, selecting from the list of the current note's
 tags."
-  (interactive (list (ekg-tags-complete
-                      :prompt "Tag: "
-                      :collection (ekg-note-tags (ekg-current-note-or-error))))
+  (interactive (list (completing-read "Tag: " (ekg-note-tags (ekg-current-note-or-error))))
                ekg-notes-mode)
   (ekg-show-notes-with-tag tag))
 
@@ -2049,9 +2020,7 @@ notes are created with additional tags TAGS."
 ;;;###autoload
 (defun ekg-show-notes-with-any-tags (tags)
   "Show notes with any of TAGS."
-  (interactive (list (ekg-tags-complete-multiple
-                      :prompt "Tags: "
-                      :collection (ekg-tags))))
+  (interactive (list (completing-read-multiple "Tags: " (ekg-tags))))
   (ekg-setup-notes-buffer
    (format "tags (any): %s" (ekg-tags-display tags))
    (lambda () (ekg-get-notes-with-any-tags tags))
@@ -2060,9 +2029,7 @@ notes are created with additional tags TAGS."
 ;;;###autoload
 (defun ekg-show-notes-with-all-tags (tags)
   "Show notes that contain all TAGS."
-  (interactive (list (ekg-tags-complete-multiple
-                      :prompt "Tags: "
-                      :collection (ekg-tags))))
+  (interactive (list (completing-read-multiple "Tags: " (ekg-tags))))
   (ekg-setup-notes-buffer
    (format "tags (all): %s" (ekg-tags-display tags))
    (lambda () (sort (ekg-get-notes-with-tags tags)
@@ -2072,9 +2039,7 @@ notes are created with additional tags TAGS."
 ;;;###autoload
 (defun ekg-show-notes-with-tag (tag)
   "Show notes that contain TAG."
-  (interactive (list (ekg-tags-complete
-                      :prompt "Tag: "
-                      :collection (ekg-tags))))
+  (interactive (list (completing-read "Tag: " (ekg-tags))))
   (ekg-setup-notes-buffer
    (format "tag: %s" (ekg-tags-display (list tag)))
    (lambda () (sort (ekg-get-notes-with-tag tag) #'ekg-sort-by-creation-time))

--- a/ekg.el
+++ b/ekg.el
@@ -1872,15 +1872,31 @@ See also `ekg-tags-complete', and `ekg-tags'."
   "Select a doc/tag from the current `ekg-db' as if by `ekg-tags-complete'.
 When optional arg MULTIPLE is non-nil, select multiple tags as if by
 `ekg-tags-complete-multiple'.
-See also `ekg-tags-with-prefix'."
+See also `ekg-tags-with-prefix', `ekg-tags-including', `ekg-tags-with-distance'."
+  (interactive "P")
+  (if multiple
+      (ekg-tags-complete-multiple :prompt "Select ekg \"doc/<TAG>\" tag(s): "
+                                  :collection (ekg-tags-with-prefix "doc/")
+                                  ;; :predicate  (lambda (tag) (string-prefix-p "doc/" tag))
+                                  :initial-input "doc/")
+    (ekg-tags-complete :prompt "Select an ekg \"doc/<TAG>\" tag: "
+                       :collection (ekg-tags-with-prefix "doc/")
+                       :initial-input "doc/")))
+
+(defun ekg-tags-complete-date (&optional multiple)
+  "Select a date/tag from the current `ekg-db' as if by `ekg-tags-complete'.
+When optional arg MULTIPLE is non-nil, select multiple tags as if by
+`ekg-tags-complete-multiple'.
+See also `ekg-tags-with-prefix', `ekg-tags-including', `ekg-tags-with-distance'."
   (interactive "P")
 (if multiple
-    (ekg-tags-complete-multiple :prompt "Select ekg \"doc/<TAG>\" tag(s): "
-                                :collection (ekg-tags-with-prefix "doc/")
-                                :initial-input "doc/")
-  (ekg-tags-complete :prompt "Select an ekg \"doc/<TAG>\" tag: "
-                     :collection (ekg-tags-with-prefix "doc/")
-                     :initial-input "doc/")))
+    (ekg-tags-complete-multiple :prompt "Select ekg \"date/<TAG>\" tag(s): "
+                                :collection (ekg-tags-with-prefix "date/")
+                                ;; :predicate  (lambda (tag) (string-prefix-p "date/" tag))
+                                :initial-input "date/")
+  (ekg-tags-complete :prompt "Select an ekg \"date/<TAG>\" tag: "
+                     :collection (ekg-tags-with-prefix "date/")
+                     :initial-input "date/")))
 
 (defun ekg-tags-display (tags)
   "Return string representing a group of TAGS."

--- a/ekg.el
+++ b/ekg.el
@@ -1808,8 +1808,8 @@ tags)."
 (cl-defun ekg-tags-complete (&key prompt collection predicate require-match 
                                   initial-input hist def inherit-input-method)
   "Select an ekg tag from the current `ekg-db' as if by `completing-read'.
-Keyword arguments PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT, HIST,
-DEF, and INHERIT-INPUT-METHOD are as per `completing-read', which see.
+Keyword arguments PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
+HIST, DEF, and INHERIT-INPUT-METHOD are as per `completing-read', which see.
 See also `ekg-tags-complete-doc', `ekg-tags'."
   (interactive)
   (completing-read

--- a/ekg.el
+++ b/ekg.el
@@ -190,6 +190,14 @@ links out of them, as well as adding them to the note text."
   :type '(repeat string)
   :group 'ekg)
 
+(defcustom ege-tags-completion-function 'completing-read
+  "Completion function for use with `ekg-tags-complete'.
+The function should accept the following 8 arguments as per `completing-read':
+ PROMPT COLLECTION PREDICATE REQUIRE-MATCH 
+ INITIAL-INPUT HIST DEF INHERIT-INPUT-METHOD"
+  :type 'function
+  :group ekg)
+
 (defconst ekg-db-file-obsolete (file-name-concat user-emacs-directory "ekg.db")
   "The original database name that ekg started with.")
 

--- a/ekg.el
+++ b/ekg.el
@@ -853,8 +853,11 @@ Returns the ID of the note."
                                      (ekg-document-titles)))
              (selected-title (completing-read "Title: " title-id-pairs nil t)))
         (cdr (assoc selected-title title-id-pairs)))
-    (let* ((notes (ekg-get-notes-with-tag
-                   (completing-read "Tag: " (ekg-tags) nil t)))
+    (let* ((notes (ekg-get-notes-with-tag (ekg-tags-complete
+                                           :prompt "Tag: "
+                                           :collection (ekg-tags)
+                                           :predicate nil
+                                           :require-match t)))
            (completion-pairs (mapcar
                               (lambda (note)
                                 (cons (ekg-display-note-text note 10)

--- a/ekg.el
+++ b/ekg.el
@@ -1815,20 +1815,21 @@ tags)."
 
 (cl-defun ekg-tags-complete (&key prompt collection predicate require-match 
                                   initial-input hist def inherit-input-method)
-  "Select an ekg tag from the current `ekg-db' as if by `completing-read'.
+  "Select an ekg tag from the current `ekg-db'.
+Tag completion performed according to specified `ekg-tags-completion-function'.
 Keyword arguments PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
 HIST, DEF, and INHERIT-INPUT-METHOD are as per `completing-read', which see.
 See also `ekg-tags-complete-doc', `ekg-tags'."
   (interactive)
-  (completing-read
-   (or prompt "Select an ekg tag: ")
-   (or collection (ekg-tags))
-   predicate
-   require-match
-   initial-input
-   hist
-   def
-   inherit-input-method))
+  (apply ekg-tags-completion-function
+         (or prompt "Select an ekg tag: ")
+         (or collection (ekg-tags))
+         predicate
+         require-match
+         initial-input
+         hist
+         def
+         inherit-input-method))
 
 (defun ekg-tags-complete-doc ()
   "Select a doc/tag from the current `ekg-db' as if by `completing-read'.

--- a/ekg.el
+++ b/ekg.el
@@ -2006,7 +2006,8 @@ NAME is the base name, to which ekg will be prepended, and
 asterisks will surround (to indicate a non-file-based buffer).
 NOTES-FUNC is used to get the list of notes to display.  New
 notes are created with additional tags TAGS."
-  (let ((buf (get-buffer-create (format "*ekg %s*" name))))
+  (let ((buf (get-buffer-create (format "*ekg %s*" name)))
+        (default-directory (file-name-parent-directory ekg-db-file)))
     (set-buffer buf)
     (ekg--show-notes name notes-func tags)
     (switch-to-buffer buf)))

--- a/ekg.el
+++ b/ekg.el
@@ -2094,7 +2094,9 @@ notes are created with additional tags TAGS."
 ;;;###autoload
 (defun ekg-show-notes-with-any-tags (tags)
   "Show notes with any of TAGS."
-  (interactive (list (completing-read-multiple "Tags: " (ekg-tags))))
+  (interactive (list (ekg-tags-complete-multiple
+                      :prompt "Tags: "
+                      :collection (ekg-tags))))
   (ekg-setup-notes-buffer
    (format "tags (any): %s" (ekg-tags-display tags))
    (lambda () (ekg-get-notes-with-any-tags tags))

--- a/ekg.el
+++ b/ekg.el
@@ -856,7 +856,6 @@ Returns the ID of the note."
     (let* ((notes (ekg-get-notes-with-tag (ekg-tags-complete
                                            :prompt "Tag: "
                                            :collection (ekg-tags)
-                                           :predicate nil
                                            :require-match t)))
            (completion-pairs (mapcar
                               (lambda (note)
@@ -1790,7 +1789,6 @@ FROM-TAG will use TO-TAG."
   (interactive (list (ekg-tags-complete
                       :prompt "From tag: "
                       :collection (ekg-tags)
-                      :predicate nil
                       :require-match t)
                      (ekg--normalize-tag 
                       (ekg-tags-complete 

--- a/ekg.el
+++ b/ekg.el
@@ -1805,6 +1805,30 @@ tags)."
   (seq-filter (lambda (tag) (string-match-p (rx (seq line-start (literal prefix))) tag))
               (triples-subjects-of-type ekg-db 'tag)))
 
+(cl-defun ekg-tags-complete (&key prompt collection predicate require-match 
+                                  initial-input hist def inherit-input-method)
+  "Select an ekg tag from the current `ekg-db' as if by `completing-read'.
+Keyword arguments PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT, HIST,
+DEF, and INHERIT-INPUT-METHOD are as per `completing-read', which see.
+See also `ekg-tags-complete-doc', `ekg-tags'."
+  (interactive)
+  (completing-read
+   (or prompt "Select an ekg tag: ")
+   (or collection (ekg-tags))
+   predicate
+   require-match
+   initial-input
+   hist
+   def
+   inherit-input-method))
+
+(defun ekg-tags-complete-doc ()
+  "Select a doc/tag from the current `ekg-db' as if by `completing-read'.
+See also `ekg-tags-complete'."
+  (interactive)
+  (ekg-tags-complete :prompt "Select an ekg \"doc/<TAG>\" tag: "
+                     :initial-input "doc/"))
+
 (defun ekg-tags-display (tags)
   "Return string representing a group of TAGS."
   (mapconcat #'identity

--- a/ekg.el
+++ b/ekg.el
@@ -190,7 +190,7 @@ links out of them, as well as adding them to the note text."
   :type '(repeat string)
   :group 'ekg)
 
-(defcustom ekg-tags-complete-function 'completing-read
+(defcustom ekg-tags-complete-function 'completing-read ; 'completing-read-default
   "Completion function for use with `ekg-tags-complete'.
 The function should accept the following 8 arguments as per `completing-read':
 

--- a/ekg.el
+++ b/ekg.el
@@ -312,7 +312,7 @@ non-nil, it will be used as the filename, otherwise
 (defun ekg--notes-directory ()
   "Return the directory ekg notes buffers have as the default directory.
 This will be the location of the database file."
-  (file-name-parent-directory
+  (file-name-directory
    (or (ekg-db-file)
        triples-default-database-filename)))
 

--- a/ekg.el
+++ b/ekg.el
@@ -1933,7 +1933,9 @@ Raise an error if there is no current note."
   "Show notes associated with TAG.
 If TAG is nil, it will be read, selecting from the list of the current note's
 tags."
-  (interactive (list (completing-read "Tag: " (ekg-note-tags (ekg-current-note-or-error))))
+  (interactive (list (ekg-tags-complete
+                      :prompt "Tag: "
+                      :collection (ekg-note-tags (ekg-current-note-or-error))))
                ekg-notes-mode)
   (ekg-show-notes-with-tag tag))
 

--- a/ekg.el
+++ b/ekg.el
@@ -309,6 +309,13 @@ non-nil, it will be used as the filename, otherwise
       ekg-db-file-obsolete
     ekg-db-file))
 
+(defun ekg--notes-directory ()
+  "Return the directory ekg notes buffers have as the default directory.
+This will be the location of the database file."
+  (file-name-parent-directory
+   (or (ekg-db-file)
+       triples-default-database-filename)))
+
 ;; `ekg-connect' will do things that might themselves call `ekg-connect', so we
 ;; need to protect against an infinite recursion.
 (defalias 'ekg-connect
@@ -2010,7 +2017,7 @@ notes are created with additional tags TAGS."
     (set-buffer buf)
     (ekg--show-notes name notes-func tags)
     (switch-to-buffer buf)
-    (setq-local default-directory (file-name-parent-directory ekg-db-file))))
+    (setq-local default-directory (ekg--notes-directory))))
 
 (defun ekg-sort-by-creation-time (a b)
   "Used to pass to `sort', which will supply A and B."

--- a/ekg.el
+++ b/ekg.el
@@ -2030,11 +2030,11 @@ NAME is the base name, to which ekg will be prepended, and
 asterisks will surround (to indicate a non-file-based buffer).
 NOTES-FUNC is used to get the list of notes to display.  New
 notes are created with additional tags TAGS."
-  (let ((buf (get-buffer-create (format "*ekg %s*" name)))
-        (default-directory (file-name-parent-directory ekg-db-file)))
+  (let ((buf (get-buffer-create (format "*ekg %s*" name))))
     (set-buffer buf)
     (ekg--show-notes name notes-func tags)
-    (switch-to-buffer buf)))
+    (switch-to-buffer buf)
+    (setq-local default-directory (file-name-parent-directory ekg-db-file))))
 
 (defun ekg-sort-by-creation-time (a b)
   "Used to pass to `sort', which will supply A and B."

--- a/ekg.el
+++ b/ekg.el
@@ -1842,6 +1842,24 @@ See also `ekg-tags-complete-doc', `ekg-tags'."
          def
          inherit-input-method))
 
+(cl-defun ekg-tags-complete-multiple (&key prompt collection predicate require-match 
+                                           initial-input hist def inherit-input-method)
+  "Select one or more ekg tags from the current `ekg-db'.
+Tag\(s\) completion performed according to `ekg-tags-complete-multiple-function'.
+Keyword arguments PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
+HIST, DEF, and INHERIT-INPUT-METHOD are as per `completing-read', which see.
+See also `ekg-tags-complete-doc', `ekg-tags'."
+  (interactive)
+  (apply ekg-tags-complete-multiple-function
+         (or prompt "Select ekg tag(s): ")
+         (or collection (ekg-tags))
+         predicate
+         require-match
+         initial-input
+         hist
+         def
+         inherit-input-method))
+
 (defun ekg-tags-complete-doc ()
   "Select a doc/tag from the current `ekg-db' as if by `completing-read'.
 See also `ekg-tags-complete'."

--- a/ekg.el
+++ b/ekg.el
@@ -190,7 +190,7 @@ links out of them, as well as adding them to the note text."
   :type '(repeat string)
   :group 'ekg)
 
-(defcustom ege-tags-completion-function 'completing-read
+(defcustom ekg-tags-completion-function 'completing-read
   "Completion function for use with `ekg-tags-complete'.
 The function should accept the following 8 arguments as per `completing-read':
  PROMPT COLLECTION PREDICATE REQUIRE-MATCH 

--- a/ekg.el
+++ b/ekg.el
@@ -194,7 +194,7 @@ links out of them, as well as adding them to the note text."
   "Completion function for use with `ekg-tags-complete'.
 The function should accept the following 8 arguments as per `completing-read':
 
- PROMPT COLLECTION PREDICATE REQUIRE-MATCH 
+ PROMPT COLLECTION PREDICATE REQUIRE-MATCH
  INITIAL-INPUT HIST DEF INHERIT-INPUT-METHOD"
   :type 'function
   :group 'ekg)
@@ -204,7 +204,7 @@ The function should accept the following 8 arguments as per `completing-read':
 Default value is `completing-read-multiple', which see.
 The function should accept the following 8 arguments as per `completing-read':
 
- PROMPT COLLECTION PREDICATE REQUIRE-MATCH 
+ PROMPT COLLECTION PREDICATE REQUIRE-MATCH
  INITIAL-INPUT HIST DEF INHERIT-INPUT-METHOD"
   :type 'function
   :group 'ekg)
@@ -1790,8 +1790,8 @@ FROM-TAG will use TO-TAG."
                       :prompt "From tag: "
                       :collection (ekg-tags)
                       :require-match t)
-                     (ekg--normalize-tag 
-                      (ekg-tags-complete 
+                     (ekg--normalize-tag
+                      (ekg-tags-complete
                        :prompt "To tag: "
                        :collection (ekg-tags)))))
   (ekg-connect)
@@ -1831,93 +1831,6 @@ tags)."
   (ekg-connect)
   (seq-filter (lambda (tag) (string-match-p (rx (seq line-start (literal prefix))) tag))
               (triples-subjects-of-type ekg-db 'tag)))
-
-(defun ekg-tags-with-distance (string distance &optional predicate)
-  "Return all tags with a `string-distance' from STRING `<=' DISTANCE.
-STRING is a string.
-DISTANCE is an positive integer value, and shuold satsify `natnump'.
-PREDICATE is a numeric comparison predicate. When non-nil it should be one of
-following `=', `<', `>', `/=', `<=', or `>='. Default is `<='.
-See also `ekg-tags-including', `ekg-tags-with-prefix'."
-  (or (stringp string)
-      (error "Argument STRING does not satisfy `stringp'. got: %s" string))
-  (or (and (integerp distance) (>= distance 0))
-      (error "Argument DISTANCE not `natnump', got: %s" distance))
-  (and predicate (or (memq predicate '(= < > /= <= >=))
-                     (error "Argument PREDICATE must be one of `=', `<', `>', `/=',`<=', or `>='")))
-  (ekg-connect)
-  (seq-filter (lambda (tag) (funcall (or predicate '<=)
-                                     (string-distance string tag)
-                                     distance))
-              (triples-subjects-of-type ekg-db 'tag)))
-
-(cl-defun ekg-tags-complete (&key prompt collection predicate require-match 
-                                  initial-input hist def inherit-input-method)
-  "Select an ekg tag from the current `ekg-db'.
-Tag completion performed according to `ekg-tags-complete-function'.
-Keyword arguments PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
-HIST, DEF, and INHERIT-INPUT-METHOD are as per `completing-read', which see.
-See also `ekg-tags-complete-multiple', `ekg-tags-complete-doc', and `ekg-tags'."
-  (interactive)
-  (ekg-connect)
-  (apply ekg-tags-complete-function
-         (or prompt "Select an ekg tag: ")
-         (or collection (ekg-tags))
-         predicate
-         require-match
-         initial-input
-         hist
-         def
-         inherit-input-method))
-
-(cl-defun ekg-tags-complete-multiple (&key prompt collection predicate require-match 
-                                           initial-input hist def inherit-input-method)
-  "Select one or more ekg tags from the current `ekg-db'.
-Tag\(s\) completion performed according to `ekg-tags-complete-multiple-function'.
-Keyword arguments PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
-HIST, DEF, and INHERIT-INPUT-METHOD are as per `completing-read', which see.
-See also `ekg-tags-complete', and `ekg-tags'."
-  (interactive)
-  (ekg-connect)
-  (apply ekg-tags-complete-multiple-function
-         (or prompt "Select ekg tag(s): ")
-         (or collection (ekg-tags))
-         predicate
-         require-match
-         initial-input
-         hist
-         def
-         inherit-input-method))
-
-(defun ekg-tags-complete-doc (&optional multiple)
-  "Select a doc/tag from the current `ekg-db' as if by `ekg-tags-complete'.
-When optional arg MULTIPLE is non-nil, select multiple tags as if by
-`ekg-tags-complete-multiple'.
-See also `ekg-tags-with-prefix', `ekg-tags-including', `ekg-tags-with-distance'."
-  (interactive "P")
-  (if multiple
-      (ekg-tags-complete-multiple :prompt "Select ekg \"doc/<TAG>\" tag(s): "
-                                  :collection (ekg-tags-with-prefix "doc/")
-                                  ;; :predicate  (lambda (tag) (string-prefix-p "doc/" tag))
-                                  :initial-input "doc/")
-    (ekg-tags-complete :prompt "Select an ekg \"doc/<TAG>\" tag: "
-                       :collection (ekg-tags-with-prefix "doc/")
-                       :initial-input "doc/")))
-
-(defun ekg-tags-complete-date (&optional multiple)
-  "Select a date/tag from the current `ekg-db' as if by `ekg-tags-complete'.
-When optional arg MULTIPLE is non-nil, select multiple tags as if by
-`ekg-tags-complete-multiple'.
-See also `ekg-tags-with-prefix', `ekg-tags-including', `ekg-tags-with-distance'."
-  (interactive "P")
-(if multiple
-    (ekg-tags-complete-multiple :prompt "Select ekg \"date/<TAG>\" tag(s): "
-                                :collection (ekg-tags-with-prefix "date/")
-                                ;; :predicate  (lambda (tag) (string-prefix-p "date/" tag))
-                                :initial-input "date/")
-  (ekg-tags-complete :prompt "Select an ekg \"date/<TAG>\" tag: "
-                     :collection (ekg-tags-with-prefix "date/")
-                     :initial-input "date/")))
 
 (defun ekg-tags-display (tags)
   "Return string representing a group of TAGS."
@@ -2159,8 +2072,8 @@ notes are created with additional tags TAGS."
 ;;;###autoload
 (defun ekg-show-notes-with-tag (tag)
   "Show notes that contain TAG."
-  (interactive (list (ekg-tags-complete 
-                      :prompt "Tag: " 
+  (interactive (list (ekg-tags-complete
+                      :prompt "Tag: "
                       :collection (ekg-tags))))
   (ekg-setup-notes-buffer
    (format "tag: %s" (ekg-tags-display (list tag)))

--- a/ekg.el
+++ b/ekg.el
@@ -1859,6 +1859,7 @@ Keyword arguments PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
 HIST, DEF, and INHERIT-INPUT-METHOD are as per `completing-read', which see.
 See also `ekg-tags-complete-multiple', `ekg-tags-complete-doc', and `ekg-tags'."
   (interactive)
+  (ekg-connect)
   (apply ekg-tags-complete-function
          (or prompt "Select an ekg tag: ")
          (or collection (ekg-tags))
@@ -1877,6 +1878,7 @@ Keyword arguments PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
 HIST, DEF, and INHERIT-INPUT-METHOD are as per `completing-read', which see.
 See also `ekg-tags-complete', and `ekg-tags'."
   (interactive)
+  (ekg-connect)
   (apply ekg-tags-complete-multiple-function
          (or prompt "Select ekg tag(s): ")
          (or collection (ekg-tags))

--- a/ekg.el
+++ b/ekg.el
@@ -196,7 +196,7 @@ The function should accept the following 8 arguments as per `completing-read':
  PROMPT COLLECTION PREDICATE REQUIRE-MATCH 
  INITIAL-INPUT HIST DEF INHERIT-INPUT-METHOD"
   :type 'function
-  :group ekg)
+  :group 'ekg)
 
 (defconst ekg-db-file-obsolete (file-name-concat user-emacs-directory "ekg.db")
   "The original database name that ekg started with.")

--- a/ekg.el
+++ b/ekg.el
@@ -1870,12 +1870,19 @@ See also `ekg-tags-complete-doc', `ekg-tags'."
          def
          inherit-input-method))
 
-(defun ekg-tags-complete-doc ()
-  "Select a doc/tag from the current `ekg-db' as if by `completing-read'.
-See also `ekg-tags-complete'."
-  (interactive)
+(defun ekg-tags-complete-doc (&optional multiple)
+  "Select a doc/tag from the current `ekg-db' as if by `ekg-tags-complete'.
+When optional arg MULTIPLE is non-nil, select multiple tags as if by
+`ekg-tags-complete-multiple'.
+See also `ekg-tags-with-prefix'."
+  (interactive "P")
+(if multiple
+    (ekg-tags-complete-multiple :prompt "Select ekg \"doc/<TAG>\" tag(s): "
+                                :collection (ekg-tags-with-prefix "doc/")
+                                :initial-input "doc/")
   (ekg-tags-complete :prompt "Select an ekg \"doc/<TAG>\" tag: "
-                     :initial-input "doc/"))
+                     :collection (ekg-tags-with-prefix "doc/")
+                     :initial-input "doc/")))
 
 (defun ekg-tags-display (tags)
   "Return string representing a group of TAGS."

--- a/ekg.el
+++ b/ekg.el
@@ -1827,12 +1827,12 @@ tags)."
 (cl-defun ekg-tags-complete (&key prompt collection predicate require-match 
                                   initial-input hist def inherit-input-method)
   "Select an ekg tag from the current `ekg-db'.
-Tag completion performed according to specified `ekg-tags-completion-function'.
+Tag completion performed according to `ekg-tags-complete-function'.
 Keyword arguments PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
 HIST, DEF, and INHERIT-INPUT-METHOD are as per `completing-read', which see.
 See also `ekg-tags-complete-doc', `ekg-tags'."
   (interactive)
-  (apply ekg-tags-completion-function
+  (apply ekg-tags-complete-function
          (or prompt "Select an ekg tag: ")
          (or collection (ekg-tags))
          predicate

--- a/ekg.el
+++ b/ekg.el
@@ -1832,6 +1832,25 @@ tags)."
   (seq-filter (lambda (tag) (string-match-p (rx (seq line-start (literal prefix))) tag))
               (triples-subjects-of-type ekg-db 'tag)))
 
+(defun ekg-tags-with-distance (string distance &optional predicate)
+  "Return all tags with a `string-distance' from STRING `<=' DISTANCE.
+STRING is a string.
+DISTANCE is an positive integer value, and shuold satsify `natnump'.
+PREDICATE is a numeric comparison predicate. When non-nil it should be one of
+following `=', `<', `>', `/=', `<=', or `>='. Default is `<='.
+See also `ekg-tags-including', `ekg-tags-with-prefix'."
+  (or (stringp string)
+      (error "Argument STRING does not satisfy `stringp'. got: %s" string))
+  (or (and (integerp distance) (>= distance 0))
+      (error "Argument DISTANCE not `natnump', got: %s" distance))
+  (and predicate (or (memq predicate '(= < > /= <= >=))
+                     (error "Argument PREDICATE must be one of `=', `<', `>', `/=',`<=', or `>='")))
+  (ekg-connect)
+  (seq-filter (lambda (tag) (funcall (or predicate '<=)
+                                     (string-distance string tag)
+                                     distance))
+              (triples-subjects-of-type ekg-db 'tag)))
+
 (cl-defun ekg-tags-complete (&key prompt collection predicate require-match 
                                   initial-input hist def inherit-input-method)
   "Select an ekg tag from the current `ekg-db'.

--- a/ekg.el
+++ b/ekg.el
@@ -1840,7 +1840,7 @@ tags)."
 Tag completion performed according to `ekg-tags-complete-function'.
 Keyword arguments PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
 HIST, DEF, and INHERIT-INPUT-METHOD are as per `completing-read', which see.
-See also `ekg-tags-complete-doc', `ekg-tags'."
+See also `ekg-tags-complete-multiple', `ekg-tags-complete-doc', and `ekg-tags'."
   (interactive)
   (apply ekg-tags-complete-function
          (or prompt "Select an ekg tag: ")
@@ -1858,7 +1858,7 @@ See also `ekg-tags-complete-doc', `ekg-tags'."
 Tag\(s\) completion performed according to `ekg-tags-complete-multiple-function'.
 Keyword arguments PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
 HIST, DEF, and INHERIT-INPUT-METHOD are as per `completing-read', which see.
-See also `ekg-tags-complete-doc', `ekg-tags'."
+See also `ekg-tags-complete', and `ekg-tags'."
   (interactive)
   (apply ekg-tags-complete-multiple-function
          (or prompt "Select ekg tag(s): ")

--- a/ekg.el
+++ b/ekg.el
@@ -1787,8 +1787,15 @@ executing a write if there is a problem."
 This can be done whether TO-TAG already exists or not.  This
 renames all instances of the tag globally, and all notes with
 FROM-TAG will use TO-TAG."
-  (interactive (list (completing-read "From tag: " (ekg-tags) nil t)
-                     (ekg--normalize-tag (completing-read "To tag: " (ekg-tags)))))
+  (interactive (list (ekg-tags-complete
+                      :prompt "From tag: "
+                      :collection (ekg-tags)
+                      :predicate nil
+                      :require-match t)
+                     (ekg--normalize-tag 
+                      (ekg-tags-complete 
+                       :prompt "To tag: "
+                       :collection (ekg-tags)))))
   (ekg-connect)
   (triples-with-transaction
     ekg-db

--- a/ekg.el
+++ b/ekg.el
@@ -190,9 +190,20 @@ links out of them, as well as adding them to the note text."
   :type '(repeat string)
   :group 'ekg)
 
-(defcustom ekg-tags-completion-function 'completing-read
+(defcustom ekg-tags-complete-function 'completing-read
   "Completion function for use with `ekg-tags-complete'.
 The function should accept the following 8 arguments as per `completing-read':
+
+ PROMPT COLLECTION PREDICATE REQUIRE-MATCH 
+ INITIAL-INPUT HIST DEF INHERIT-INPUT-METHOD"
+  :type 'function
+  :group 'ekg)
+
+(defcustom ekg-tags-complete-multiple-function 'completing-read-multiple
+  "Completion function for use with `ekg-tags-complete-multiple'.
+Default value is `completing-read-multiple', which see.
+The function should accept the following 8 arguments as per `completing-read':
+
  PROMPT COLLECTION PREDICATE REQUIRE-MATCH 
  INITIAL-INPUT HIST DEF INHERIT-INPUT-METHOD"
   :type 'function

--- a/ekg.el
+++ b/ekg.el
@@ -2105,7 +2105,9 @@ notes are created with additional tags TAGS."
 ;;;###autoload
 (defun ekg-show-notes-with-all-tags (tags)
   "Show notes that contain all TAGS."
-  (interactive (list (completing-read-multiple "Tags: " (ekg-tags))))
+  (interactive (list (ekg-tags-complete-multiple
+                      :prompt "Tags: "
+                      :collection (ekg-tags))))
   (ekg-setup-notes-buffer
    (format "tags (all): %s" (ekg-tags-display tags))
    (lambda () (sort (ekg-get-notes-with-tags tags)


### PR DESCRIPTION
`ekg-setup-notes-buffer` `setq-local` of `default-directory` to `ekg-db-file` parent directory.
The intention here is that the notes buffer should default to the parent directory of the user's `ekg-db-file`.  I was surprised when evaluating `ekg-show-notes-latest-captured` (and similar functions), that the `"*ekg <FOO>*"` notes buffer defaulted to whichever directory the `ekg-show-<FOO>` function was called-interactively from.  I expected these types of ekg commands would default to a consistent location. It makes more sense to me that the consistent location be the parent directory of the `ekb-db-file` rather than an arbitrary directory that potentially changes each time a notes buffer is presented. Note, the first attempt at commit [c6f3a9b](https://github.com/ahyatt/ekg/pull/182/commits/c6f3a9bfdb34d217cfaeb4fa05a8d6845e31079e) to let bind `default-directory` doesn't work, but the `setq-local` of `default-directory` at commit [0bd4050](https://github.com/ahyatt/ekg/pull/182/commits/0bd405027b0f0bc3f225783d660ead9426f31877) does work as intended.

Added two new basic built-in ekg-tags completion functions:
`ekg-tags-complete` and `ekg-tags-complete-doc`

These seemed lacking in the API, and would be useful (esp. for beginning ekg users).

Presumably, as the number of tags increase, there may be a need to filter some tags presented via completion, hence I've used CL style keywords in anticipation of that eventual need and to cut down on the cognitive overhead of 8 &optional arguments.

See [idea discussion 181](https://github.com/ahyatt/ekg/discussions/181).
