### PR TITLE
Add text queries with ekg-show-notes-for-query via new triples-fts

### DIFF
--- a/README.org
+++ b/README.org
@@ -176,6 +176,7 @@ Global commands, can be run everywhere, and most should be bound to useful keybi
 | =ekg-show-notes-with-tag=        | Open a buffer for notes matching the single tag given                     |
 | =ekg-show-notes-with-any-tags=   | Open a buffer for notes matching any of the given tags                    |
 | =ekg-show-notes-with-all-tags=   | Open a buffer for notes matching all of the given tags                    |
+| ekg-show-notes-for-query       | Open a buffer for notes with text matching query                          |
 | =ekg-show-notes-with-tag-prefix= | Open a buffer for notes matching any tag with a tag with the given prefix |
 | =ekg-show-notes-in-trash=        | Open a tag buffer that shows all notes in the trash                       |
 | =ekg-show-notes-in-drafts=       | Open a tag buffer that shows all draft notes (saved but not finalized)    |

--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -62,6 +62,7 @@ Clone the ekg library, from whatever branch you would like to use (=main= corres
 - Fix inclusion of title-based transclusion ">t", which included the "t" as part of the completion.
 - Fix tag renaming possibly causing duplication.
 - Ensure renamed tags are normalized.
+- Add new cleanup: =ekg-clean-propertized-text=, run on =ekg-clean-db=.
 ** Version 0.4.1
 - Fix issues using default emacs in-buffer completion, and allowing completion in places we shouldn't.
 - Add =ekg-embedding-generate-on-save= and =ekg-embedding-disable-generate-on-save= to turn off generating embeddings for notes.

--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -546,7 +546,7 @@ This is a =ekg-notes-mode= buffer.
 
 =ekg-show-notes-with-all-tags= will show all notes that have all of the tags given.
 
-=ekg-show-notes-for-query= will do a ranked text search, showing all results.  The query is token-based so querying for individual characters and syntax will not work; the query has to be words.  Prefixes such as "tag", "title" and "text" can be used to restrict matches to tags, titles and text respectively.  For example, the query "tag:apartment sink" will show any article with "sink" in it (it could be anywhere, even a tag), but it also has to have a tag with "apartment" in it.  Every term is ANDed together.  Use quotes if you want to quote a phrase such as "tag:\"apartment problems\" sink".
+=ekg-show-notes-for-query= will do a ranked text search, showing all results.  The query is token-based so querying for individual characters and syntax will not work; the query has to be words.  Prefixes such as "tag", "title" and "text" can be used to restrict matches to tags, titles and text respectively.  For example, the query "tag:apartment sink" will show any article with "sink" in it (it could be anywhere, even a tag), but it also has to have a tag with "apartment" in it.  Every term is ANDed together.  Use quotes if you want to quote a phrase such as "tag:\"apartment problems\" sink".  This does not search anything included via inline commands.
 
 =ekg-show-notes-for-today= will show the notes taken today.
 

--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -73,6 +73,8 @@ triples library is already installed.
 (require 'ekg)
 #+end_src
 * Changelog
+** Version 0.7.0
+- Added =ekg-show-notes-for-query= using =triples-fts=.
 ** Version 0.6.4
 - Fix display of extended structured data in notes.
 - Add contrib directory and =ekg-email= as a contribution to import emails to notes in a structured way.
@@ -542,6 +544,8 @@ This is a =ekg-notes-mode= buffer.
 =ekg-show-notes-with-any-tags= will show all notes that have any of the tags given.
 
 =ekg-show-notes-with-all-tags= will show all notes that have all of the tags given.
+
+=ekg-show-notes-for-query= will do a ranked text search, showing all results.  The query is token-based so querying for individual characters and syntax will not work; the query has to be words.  Prefixes such as "tag", "title" and "text" can be used to restrict matches to tags, titles and text respectively.  For example, the query "tag:apartment sink" will show any article with "sink" in it (it could be anywhere, even a tag), but it also has to have a tag with "apartment" in it.  Every term is ANDed together.  Use quotes if you want to quote a phrase such as "tag:\"apartment problems\" sink".
 
 =ekg-show-notes-for-today= will show the notes taken today.
 

--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -546,7 +546,7 @@ This is a =ekg-notes-mode= buffer.
 
 =ekg-show-notes-with-all-tags= will show all notes that have all of the tags given.
 
-=ekg-show-notes-for-query= will do a ranked text search, showing all results.  The query is token-based so querying for individual characters and syntax will not work; the query has to be words.  Prefixes such as "tag", "title" and "text" can be used to restrict matches to tags, titles and text respectively.  For example, the query "tag:apartment sink" will show any article with "sink" in it (it could be anywhere, even a tag), but it also has to have a tag with "apartment" in it.  Every term is ANDed together.  Use quotes if you want to quote a phrase such as "tag:\"apartment problems\" sink".  This does not search anything included via inline commands.
+=ekg-show-notes-for-query= will do a ranked text search, showing all results.  The query is token-based so querying for individual characters and syntax will not work; the query has to be words.  Prefixes such as "tag", "title" and "text" can be used to restrict matches to tags, titles and text respectively.  For example, the query "tag:apartment sink" will show any article with "sink" in it (it could be anywhere, even a tag), but it also has to have a tag with "apartment" in it.  Every term is ANDed together.  Use quotes if you want to quote a phrase such as "tag:\"apartment problems\" sink".  This does not search anything included via inline commands.  This is only possible for those using the built-in sqlite backend in Emacs 29.1 or later.
 
 =ekg-show-notes-for-today= will show the notes taken today.
 

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -943,7 +943,7 @@ This is a @samp{ekg-notes-mode} buffer.
 
 @samp{ekg-show-notes-with-all-tags} will show all notes that have all of the tags given.
 
-@samp{ekg-show-notes-for-query} will do a ranked text search, showing all results.  The query is token-based so querying for individual characters and syntax will not work; the query has to be words.  Prefixes such as "tag", "title" and "text" can be used to restrict matches to tags, titles and text respectively.  For example, the query "tag:apartment sink" will show any article with "sink" in it (it could be anywhere, even a tag), but it also has to have a tag with "apartment" in it.  Every term is ANDed together.  Use quotes if you want to quote a phrase such as "tag:\"apartment problems\" sink".  This does not search anything included via inline commands.
+@samp{ekg-show-notes-for-query} will do a ranked text search, showing all results.  The query is token-based so querying for individual characters and syntax will not work; the query has to be words.  Prefixes such as "tag", "title" and "text" can be used to restrict matches to tags, titles and text respectively.  For example, the query "tag:apartment sink" will show any article with "sink" in it (it could be anywhere, even a tag), but it also has to have a tag with "apartment" in it.  Every term is ANDed together.  Use quotes if you want to quote a phrase such as "tag:\"apartment problems\" sink".  This does not search anything included via inline commands.  This is only possible for those using the built-in sqlite backend in Emacs 29.1 or later.
 
 @samp{ekg-show-notes-for-today} will show the notes taken today.
 

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -943,7 +943,7 @@ This is a @samp{ekg-notes-mode} buffer.
 
 @samp{ekg-show-notes-with-all-tags} will show all notes that have all of the tags given.
 
-@samp{ekg-show-notes-for-query} will do a ranked text search, showing all results.  The query is token-based so querying for individual characters and syntax will not work; the query has to be words.  Prefixes such as "tag", "title" and "text" can be used to restrict matches to tags, titles and text respectively.  For example, the query "tag:apartment sink" will show any article with "sink" in it (it could be anywhere, even a tag), but it also has to have a tag with "apartment" in it.  Every term is ANDed together.  Use quotes if you want to quote a phrase such as "tag:\"apartment problems\" sink".
+@samp{ekg-show-notes-for-query} will do a ranked text search, showing all results.  The query is token-based so querying for individual characters and syntax will not work; the query has to be words.  Prefixes such as "tag", "title" and "text" can be used to restrict matches to tags, titles and text respectively.  For example, the query "tag:apartment sink" will show any article with "sink" in it (it could be anywhere, even a tag), but it also has to have a tag with "apartment" in it.  Every term is ANDed together.  Use quotes if you want to quote a phrase such as "tag:\"apartment problems\" sink".  This does not search anything included via inline commands.
 
 @samp{ekg-show-notes-for-today} will show the notes taken today.
 

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -200,6 +200,8 @@ Fix inclusion of title-based transclusion ">t", which included the "t" as part o
 Fix tag renaming possibly causing duplication.
 @item
 Ensure renamed tags are normalized.
+@item
+Add new cleanup: @samp{ekg-clean-propertized-text}, run on @samp{ekg-clean-db}.
 @end itemize
 
 @node Version 041

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -68,6 +68,7 @@ Installation
 
 Changelog
 
+* Version 0.7.0: Version 070. 
 * Version 0.6.4: Version 064. 
 * Version 0.6.3: Version 063. 
 * Version 0.6.2: Version 062. 
@@ -204,6 +205,7 @@ triples library is already installed.
 @chapter Changelog
 
 @menu
+* Version 0.7.0: Version 070. 
 * Version 0.6.4: Version 064. 
 * Version 0.6.3: Version 063. 
 * Version 0.6.2: Version 062. 
@@ -222,6 +224,14 @@ triples library is already installed.
 * Version 0.2.1: Version 021. 
 * Version 0.2: Version 02. 
 @end menu
+
+@node Version 070
+@section Version 0.7.0
+
+@itemize
+@item
+Added @samp{ekg-show-notes-for-query} using @samp{triples-fts}.
+@end itemize
 
 @node Version 064
 @section Version 0.6.4
@@ -930,6 +940,8 @@ This is a @samp{ekg-notes-mode} buffer.
 @samp{ekg-show-notes-with-any-tags} will show all notes that have any of the tags given.
 
 @samp{ekg-show-notes-with-all-tags} will show all notes that have all of the tags given.
+
+@samp{ekg-show-notes-for-query} will do a ranked text search, showing all results.  The query is token-based so querying for individual characters and syntax will not work; the query has to be words.  Prefixes such as "tag", "title" and "text" can be used to restrict matches to tags, titles and text respectively.  For example, the query "tag:apartment sink" will show any article with "sink" in it (it could be anywhere, even a tag), but it also has to have a tag with "apartment" in it.  Every term is ANDed together.  Use quotes if you want to quote a phrase such as "tag:\"apartment problems\" sink".
 
 @samp{ekg-show-notes-for-today} will show the notes taken today.
 

--- a/ekg.el
+++ b/ekg.el
@@ -1873,6 +1873,16 @@ the database after the upgrade, in list form."
            do
            (ekg-tag-delete tag)))
 
+(defun ekg-clean-propertized-text ()
+  "Find text with propertized text and remove the properties."
+  (cl-loop for s in (triples-fts-query ekg-db "face") do
+           (let* ((text-plist (triples-get-type ekg-db s 'text))
+                  (text (plist-get text-plist :text))
+                  (cleaned (substring-no-properties text)))
+             (unless (equal-including-properties text cleaned)
+               (message "Found propertized text in %s, cleaning" s)
+               (apply #'triples-set-type ekg-db s 'text (plist-put text-plist :text cleaned))))))
+
 (defun ekg-clean-db ()
   "Clean all useless or malformed data from the database.
 Some of this are tags which have no uses, which we consider
@@ -1936,7 +1946,8 @@ long as those notes aren't on resources that are interesting.
                                                         (when empty-note "empty"))) ", "))
                  (ekg-note-delete note))))))
   (ekg-clean-dup-tags)
-  (ekg-clean-leftover-types))
+  (ekg-clean-leftover-types)
+  (ekg-clean-propertized-text))
 
 ;; Links for org-mode
 (require 'ol)

--- a/ekg.el
+++ b/ekg.el
@@ -2084,7 +2084,17 @@ notes are created with additional tags TAGS."
 
 ;;;###autoload
 (defun ekg-show-notes-for-query (query)
-  "Show notes matching TEXT."
+  "Show notes matching QUERY.
+
+This does a token-based search, so single letters or word fragments and
+punctuation may not match.
+
+This uses `ekg-query-pred-abbrevs' to provide abbreviations for querying
+for special forms of note data.  For example, you can search for tags
+with `tag:<term>' or `title:<term>', or `text:<term>'.  Anything not
+prefixed will search any text associated with the subject.
+
+Text included in inline templates is not searched."
   (interactive "sQuery: ")
   (ekg-connect)
   (ekg-setup-notes-buffer

--- a/ekg.el
+++ b/ekg.el
@@ -6,7 +6,7 @@
 ;; Homepage: https://github.com/ahyatt/ekg
 ;; Package-Requires: ((triples "0.5.0") (emacs "28.1") (llm "0.18.0"))
 ;; Keywords: outlines, hypermedia
-;; Version: 0.6.4
+;; Version: 0.7.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
 ;; This program is free software; you can redistribute it and/or
@@ -294,7 +294,7 @@ editing the note.")
                                  ("text" . "text/text"))
   "Abbreviations for predicates in queries.")
 
-(defconst ekg-version "0.6.4"
+(defconst ekg-version "0.7.0"
   "The version of ekg.
 
 This is used to understand when the database needs upgrading.")

--- a/ekg.el
+++ b/ekg.el
@@ -4,7 +4,7 @@
 
 ;; Author: Andrew Hyatt <ahyatt@gmail.com>
 ;; Homepage: https://github.com/ahyatt/ekg
-;; Package-Requires: ((triples "0.3.5") (emacs "28.1") (llm "0.3.0"))
+;; Package-Requires: ((triples "0.3.5") (emacs "28.1") (llm "0.4.0"))
 ;; Keywords: outlines, hypermedia
 ;; Version: 0.4.2
 ;; SPDX-License-Identifier: GPL-3.0-or-later

--- a/ekg.el
+++ b/ekg.el
@@ -1043,7 +1043,10 @@ If ID is given, force the triple subject to be that value."
     (insert text)
     (if (and (eq mode 'org-mode)
              ekg-notes-display-images)
-        (org-redisplay-inline-images))
+        (condition-case nil
+            (org-redisplay-inline-images)
+          (wrong-type-argument (message "Problem showing image for note ID %s (content: \"%s\")"
+                          id (ekg-truncate-at text 10)))))
     (set-buffer-modified-p nil)
     (pop-to-buffer buf)))
 


### PR DESCRIPTION
Also update the version to 0.7.0.

This implements the querying in https://github.com/ahyatt/ekg/issues/195, and also the full-text search discussed in https://github.com/ahyatt/ekg/discussions/109.