### PR TITLE
Add character-based text truncation option

### DIFF
--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -73,6 +73,8 @@ triples library is already installed.
 (require 'ekg)
 #+end_src
 * Changelog
+** Version 0.7.2
+- Add =ekg-truncation-method= variable to control how truncation happens.
 ** Version 0.7.1
 - Don't show inactive notes with =ekg-search=.
 ** Version 0.7.0
@@ -782,23 +784,37 @@ tags added to a new note, or tags added after completing a new tag in the note's
 property list.
 
 ** Text Truncation Method
-EKG provides a way to customize how text is truncated for display (e.g., in note lists or inline transclusions) and for generating embeddings. This is controlled by the `ekg-truncation-method` variable.
+EKG provides a way to customize how text is truncated for display (e.g., in note
+lists or inline transclusions) and for generating embeddings. This is controlled
+by the `ekg-truncation-method` variable.
 
 You can set `ekg-truncation-method` to one of the following values:
-- `'word` (default): Text is truncated based on word counts. This is suitable for languages that use spaces to separate words.
-- `'character`: Text is truncated based on character counts. This method is recommended for Asian languages (such as Chinese, Japanese, Korean) that do not rely on spaces for word segmentation.
+- `'word` (default): Text is truncated based on word counts. This is suitable
+  for languages that use spaces to separate words.
+- `'character`: Text is truncated based on character counts. This method is
+  recommended for Asian languages (such as Chinese, Japanese, Korean) that do
+  not rely on spaces for word segmentation.
 
 When `ekg-truncation-method` is set to `'character'`:
-- Functions like `ekg-truncate-at` will interpret their numerical argument (e.g., `numwords` or `num`) as a character limit.
-- Numbers used in display templates (e.g., `%n(text 500)`) will refer to character limits.
-- The `ekg-embedding-text-selector-initial` function (used by the =ekg-embedding= module) will select text for embeddings based on a character limit.
+- Functions like `ekg-truncate-at` will interpret their numerical argument
+  (e.g., `numwords` or `num`) as a character limit.
+- Numbers used in display templates (e.g., `%n(text 500)`) will refer to
+  character limits.
+- The `ekg-embedding-text-selector-initial` function (used by the =ekg-embedding=
+  module) will select text for embeddings based on a character limit.
 
-Users working with Asian languages, or those who prefer character-based limits for other reasons, should set `ekg-truncation-method` in their Emacs configuration:
+Users working with Asian languages, or those who prefer character-based limits
+for other reasons, should set `ekg-truncation-method` in their Emacs
+configuration:
 #+begin_src emacs-lisp
 (setq ekg-truncation-method 'character)
 #+end_src
 
-Be mindful that if you switch to `'character'` mode, numerical limits you might have previously set for word counts (e.g., in `ekg-display-note-template` or `ekg-note-inline-max-words`) will now be interpreted as character counts. This might require adjusting those numbers to achieve your desired display length. For example, a limit of 500 words is very different from 500 characters.
+Be mindful that if you switch to `'character'` mode, numerical limits you might
+have previously set for word counts (e.g., in `ekg-display-note-template` or
+`ekg-note-inline-max-words`) will now be interpreted as character counts. This
+might require adjusting those numbers to achieve your desired display
+length. For example, a limit of 500 words is very different from 500 characters.
 * Integration with ekg
 The ekg package is designed to be easy to integrate with.  For example, if you
 want to create a note automatically in one of your functions, you can write:

--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -780,6 +780,25 @@ The ~ekg-note-delete-hook~ is called when deleting a note.
 The ~ekg-note-add-tag-hook~ is called when adding a tag, either via the initial
 tags added to a new note, or tags added after completing a new tag in the note's
 property list.
+
+** Text Truncation Method
+EKG provides a way to customize how text is truncated for display (e.g., in note lists or inline transclusions) and for generating embeddings. This is controlled by the `ekg-truncation-method` variable.
+
+You can set `ekg-truncation-method` to one of the following values:
+- `'word` (default): Text is truncated based on word counts. This is suitable for languages that use spaces to separate words.
+- `'character`: Text is truncated based on character counts. This method is recommended for Asian languages (such as Chinese, Japanese, Korean) that do not rely on spaces for word segmentation.
+
+When `ekg-truncation-method` is set to `'character'`:
+- Functions like `ekg-truncate-at` will interpret their numerical argument (e.g., `numwords` or `num`) as a character limit.
+- Numbers used in display templates (e.g., `%n(text 500)`) will refer to character limits.
+- The `ekg-embedding-text-selector-initial` function (used by the =ekg-embedding= module) will select text for embeddings based on a character limit.
+
+Users working with Asian languages, or those who prefer character-based limits for other reasons, should set `ekg-truncation-method` in their Emacs configuration:
+#+begin_src emacs-lisp
+(setq ekg-truncation-method 'character)
+#+end_src
+
+Be mindful that if you switch to `'character'` mode, numerical limits you might have previously set for word counts (e.g., in `ekg-display-note-template` or `ekg-note-inline-max-words`) will now be interpreted as character counts. This might require adjusting those numbers to achieve your desired display length. For example, a limit of 500 words is very different from 500 characters.
 * Integration with ekg
 The ekg package is designed to be easy to integrate with.  For example, if you
 want to create a note automatically in one of your functions, you can write:

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -69,6 +69,7 @@ Installation
 
 Changelog
 
+* Version 0.7.2: Version 072. 
 * Version 0.7.1: Version 071. 
 * Version 0.7.0: Version 070. 
 * Version 0.6.4: Version 064. 
@@ -211,6 +212,7 @@ triples library is already installed.
 @chapter Changelog
 
 @menu
+* Version 0.7.2: Version 072. 
 * Version 0.7.1: Version 071. 
 * Version 0.7.0: Version 070. 
 * Version 0.6.4: Version 064. 
@@ -231,6 +233,14 @@ triples library is already installed.
 * Version 0.2.1: Version 021. 
 * Version 0.2: Version 02. 
 @end menu
+
+@node Version 072
+@section Version 0.7.2
+
+@itemize
+@item
+Add @samp{ekg-truncation-method} variable to control how truncation happens.
+@end itemize
 
 @node Version 071
 @section Version 0.7.1
@@ -1236,32 +1246,46 @@ property list.
 @node Text Truncation Method
 @section Text Truncation Method
 
-EKG provides a way to customize how text is truncated for display (e.g., in note lists or inline transclusions) and for generating embeddings. This is controlled by the `ekg-truncation-method` variable.
+EKG provides a way to customize how text is truncated for display (e.g., in note
+lists or inline transclusions) and for generating embeddings. This is controlled
+by the `ekg-truncation-method` variable.
 
 You can set `ekg-truncation-method` to one of the following values:
 @itemize
 @item
-`'word` (default): Text is truncated based on word counts. This is suitable for languages that use spaces to separate words.
+`'word` (default): Text is truncated based on word counts. This is suitable
+for languages that use spaces to separate words.
 @item
-`'character`: Text is truncated based on character counts. This method is recommended for Asian languages (such as Chinese, Japanese, Korean) that do not rely on spaces for word segmentation.
+`'character`: Text is truncated based on character counts. This method is
+recommended for Asian languages (such as Chinese, Japanese, Korean) that do
+not rely on spaces for word segmentation.
 @end itemize
 
 When `ekg-truncation-method` is set to `'character'`:
 @itemize
 @item
-Functions like `ekg-truncate-at` will interpret their numerical argument (e.g., `numwords` or `num`) as a character limit.
+Functions like `ekg-truncate-at` will interpret their numerical argument
+(e.g., `numwords` or `num`) as a character limit.
 @item
-Numbers used in display templates (e.g., `%n(text 500)`) will refer to character limits.
+Numbers used in display templates (e.g., `%n(text 500)`) will refer to
+character limits.
 @item
-The `ekg-embedding-text-selector-initial` function (used by the @samp{ekg-embedding} module) will select text for embeddings based on a character limit.
+The `ekg-embedding-text-selector-initial` function (used by the @samp{ekg-embedding}
+module) will select text for embeddings based on a character limit.
 @end itemize
 
-Users working with Asian languages, or those who prefer character-based limits for other reasons, should set `ekg-truncation-method` in their Emacs configuration:
+Users working with Asian languages, or those who prefer character-based limits
+for other reasons, should set `ekg-truncation-method` in their Emacs
+configuration:
 @lisp
 (setq ekg-truncation-method 'character)
 @end lisp
 
-Be mindful that if you switch to `'character'` mode, numerical limits you might have previously set for word counts (e.g., in `ekg-display-note-template` or `ekg-note-inline-max-words`) will now be interpreted as character counts. This might require adjusting those numbers to achieve your desired display length. For example, a limit of 500 words is very different from 500 characters.
+Be mindful that if you switch to `'character'` mode, numerical limits you might
+have previously set for word counts (e.g., in `ekg-display-note-template` or
+`ekg-note-inline-max-words`) will now be interpreted as character counts. This
+might require adjusting those numbers to achieve your desired display
+length. For example, a limit of 500 words is very different from 500 characters.
 
 @node Integration with ekg
 @chapter Integration with ekg

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -107,6 +107,10 @@ Viewing tags or notes
 * Commands in the notes buffer::
 * Customizing note display in @samp{ekg-notes-mode}::
 
+Customizing ekg with hooks
+
+* Text Truncation Method::
+
 Extras
 
 * Embeddings::
@@ -1224,6 +1228,40 @@ The @code{ekg-note-delete-hook} is called when deleting a note.
 The @code{ekg-note-add-tag-hook} is called when adding a tag, either via the initial
 tags added to a new note, or tags added after completing a new tag in the note's
 property list.
+
+@menu
+* Text Truncation Method::
+@end menu
+
+@node Text Truncation Method
+@section Text Truncation Method
+
+EKG provides a way to customize how text is truncated for display (e.g., in note lists or inline transclusions) and for generating embeddings. This is controlled by the `ekg-truncation-method` variable.
+
+You can set `ekg-truncation-method` to one of the following values:
+@itemize
+@item
+`'word` (default): Text is truncated based on word counts. This is suitable for languages that use spaces to separate words.
+@item
+`'character`: Text is truncated based on character counts. This method is recommended for Asian languages (such as Chinese, Japanese, Korean) that do not rely on spaces for word segmentation.
+@end itemize
+
+When `ekg-truncation-method` is set to `'character'`:
+@itemize
+@item
+Functions like `ekg-truncate-at` will interpret their numerical argument (e.g., `numwords` or `num`) as a character limit.
+@item
+Numbers used in display templates (e.g., `%n(text 500)`) will refer to character limits.
+@item
+The `ekg-embedding-text-selector-initial` function (used by the @samp{ekg-embedding} module) will select text for embeddings based on a character limit.
+@end itemize
+
+Users working with Asian languages, or those who prefer character-based limits for other reasons, should set `ekg-truncation-method` in their Emacs configuration:
+@lisp
+(setq ekg-truncation-method 'character)
+@end lisp
+
+Be mindful that if you switch to `'character'` mode, numerical limits you might have previously set for word counts (e.g., in `ekg-display-note-template` or `ekg-note-inline-max-words`) will now be interpreted as character counts. This might require adjusting those numbers to achieve your desired display length. For example, a limit of 500 words is very different from 500 characters.
 
 @node Integration with ekg
 @chapter Integration with ekg

--- a/ekg-embedding.el
+++ b/ekg-embedding.el
@@ -294,21 +294,39 @@ closer it is to 1, the more similar it is."
 (defun ekg-embedding-text-selector-initial (text)
   "Return the TEXT to use for generating embeddings.
 This is shortened to abide by token limits, using a conservative
-approach, since it is difficult to predict the number of tokens
-exactly."
+approach. The truncation method depends on `ekg-truncation-method`
+(defined in `ekg.el`)."
   (with-temp-buffer
     (insert text)
     (goto-char (point-min))
-    ;; The target number of words we want is 8191 (the open AI limit is 8192),
-    ;; divided by a factor of 1.5 to be conservative, since one word can be
-    ;; multiple tokens.
-    (let ((target-num-words (floor (/ 8191 1.5)))
-          (num-words 0))
-      (while (and (< num-words target-num-words)
-                  (not (eobp)))
-        (forward-word)
-        (cl-incf num-words))
-      (buffer-substring-no-properties (point-min) (point)))))
+    (cond
+     ((eq ekg-truncation-method 'word)
+      ;; The target number of words we want is 8191 (the open AI limit is 8192),
+      ;; divided by a factor of 1.5 to be conservative, since one word can be
+      ;; multiple tokens.
+      (let ((target-num-words (floor (/ 8191 1.5)))
+            (num-words 0))
+        (while (and (< num-words target-num-words)
+                    (not (eobp)))
+          (forward-word 1) ; Ensure forward-word moves by 1 word
+          (cl-incf num-words))
+        (buffer-substring-no-properties (point-min) (point))))
+     ((eq ekg-truncation-method 'character)
+      ;; For character-based selection, we'll use a direct character limit.
+      ;; Assuming a conservative 1 character per token for CJK languages,
+      ;; or a general heuristic. This might need further refinement or
+      ;; a separate configurable variable in the future.
+      ;; Let's use 8191 / 1.0 for now as a starting point.
+      (let ((target-num-chars (floor (/ 8191 1.0))))
+        (buffer-substring-no-properties (point-min) (min (point-max) (+ (point-min) target-num-chars)))))
+     (t ; Default to word-based if ekg-truncation-method is somehow not set or invalid
+      (let ((target-num-words (floor (/ 8191 1.5)))
+            (num-words 0))
+        (while (and (< num-words target-num-words)
+                    (not (eobp)))
+          (forward-word 1)
+          (cl-incf num-words))
+        (buffer-substring-no-properties (point-min) (point)))))))
 
 (defun ekg-embedding-delete (id)
   "Delete embedding for ID."

--- a/ekg-embedding.el
+++ b/ekg-embedding.el
@@ -294,8 +294,8 @@ closer it is to 1, the more similar it is."
 (defun ekg-embedding-text-selector-initial (text)
   "Return the TEXT to use for generating embeddings.
 This is shortened to abide by token limits, using a conservative
-approach. The truncation method depends on `ekg-truncation-method`
-(defined in `ekg.el`)."
+approach.  The truncation method depends on `ekg-truncation-method`
+defined in `ekg.el`."
   (with-temp-buffer
     (insert text)
     (goto-char (point-min))

--- a/ekg-test.el
+++ b/ekg-test.el
@@ -447,7 +447,7 @@
   (let ((ekg-truncation-method 'word)
         (english-text "This is a sample English text for testing truncation.")
         (chinese-text "这是一段用于测试截断的示例文本"))
-    (should (string= (ekg-truncate-at text 4) "This is a sample…"))
+    (should (string= (ekg-truncate-at english-text 4) "This is a sample…"))
     (should (string= (ekg-truncate-at english-text 9) english-text))
     (should (string= (ekg-truncate-at english-text 10) english-text))
     ;; forward-word treats the entire chinese-text as one word if no spaces

--- a/ekg-test.el
+++ b/ekg-test.el
@@ -44,8 +44,7 @@
             (forward-word 1)
             (cl-incf num-words)
             (if (eq (point) start-pos) (cl-return)) ; Break if stuck
-            (when (eobp) (cl-return)))
-            )))
+            (when (eobp) (cl-return)))))
       num-words)))
 
 (ekg-deftest ekg-test-note-lifecycle ()
@@ -457,8 +456,6 @@
     (ekg--convert-inline-tags-to-links note)
     (should (equal (ekg-note-text note) "foo #[[ekg-tag:🦜][🦜]]"))))
 
-(provide 'ekg-test)
-
 (ert-deftest test-ekg-truncate-at-word ()
   "Test ekg-truncate-at with word-based truncation."
   (let ((ekg-truncation-method 'word)
@@ -477,8 +474,8 @@
         (english-text "This is a sample English text for testing truncation.")
         (chinese-text "这是一段用于测试截断的示例文本"))
     (should (string= (ekg-truncate-at english-text 10) "This is a …"))
-    (should (string= (ekg-truncate-at english-text 46) english-text))
-    (should (string= (ekg-truncate-at english-text 50) english-text))
+    (should (string= (ekg-truncate-at english-text 54) english-text))
+    (should (string= (ekg-truncate-at english-text 53) english-text))
     (should (string= (ekg-truncate-at chinese-text 5) "这是一段用…"))
     (should (string= (ekg-truncate-at chinese-text 15) chinese-text))
     (should (string= (ekg-truncate-at chinese-text 20) chinese-text))))
@@ -513,14 +510,14 @@
         (should (= (length selected-text) 8191))))
 
     (let ((very-long-english (apply #'concat (make-list 6000 "word ")))) ;; 6000 words > 5460 words
-       (setq ekg-truncation-method 'word)
-       (let ((selected-text (ekg-embedding-text-selector-initial very-long-english)))
-         (should (< (ekg-test-count-words-in-string selected-text) 6000))
-         ;; This assertion might be tricky due to how forward-word handles end of buffer
-         ;; and potential addition of "..." if that's part of the selector's behavior.
-         ;; The selector itself doesn't add "...", it just substrings.
-         ;; The primary check is that fewer words are returned than originally present.
-         (should (= (ekg-test-count-words-in-string selected-text) 5460))))
-))
+      (setq ekg-truncation-method 'word)
+      (let ((selected-text (ekg-embedding-text-selector-initial very-long-english)))
+        (should (< (ekg-test-count-words-in-string selected-text) 6000))
+        ;; This assertion might be tricky due to how forward-word handles end of buffer
+        ;; and potential addition of "..." if that's part of the selector's behavior.
+        ;; The selector itself doesn't add "...", it just substrings.
+        ;; The primary check is that fewer words are returned than originally present.
+        (should (= (ekg-test-count-words-in-string selected-text) 5460))))))
 
+(provide 'ekg-test)
 ;;; ekg-test.el ends here

--- a/ekg-test.el
+++ b/ekg-test.el
@@ -22,11 +22,31 @@
 
 ;;; Code:
 (require 'ekg)
+(require 'ekg-embedding)
 (require 'ert)
 (require 'ert-x)
 (require 'org)
 (require 'markdown-mode)
 (require 'ekg-test-utils)
+
+(defun ekg-test-count-words-in-string (text)
+  "Counts words in the given TEXT string using forward-word in a temp buffer."
+  (with-temp-buffer
+    (insert text)
+    (goto-char (point-min))
+    (let ((num-words 0))
+      ;; If buffer is empty or only whitespace, forward-word might error or loop.
+      ;; Add a check for actual content.
+      (unless (string-match-p "^\s-*$" (buffer-string))
+        (while (not (eobp))
+          ;; Check if forward-word actually moved. If not, break to avoid infinite loop.
+          (let ((start-pos (point)))
+            (forward-word 1)
+            (cl-incf num-words)
+            (if (eq (point) start-pos) (cl-return)) ; Break if stuck
+            (when (eobp) (cl-return)))
+            )))
+      num-words)))
 
 (ekg-deftest ekg-test-note-lifecycle ()
              (let ((note (ekg-note-create :text "Test text" :mode 'text-mode :tags '("tag1" "tag2"))))
@@ -438,5 +458,69 @@
     (should (equal (ekg-note-text note) "foo #[[ekg-tag:🦜][🦜]]"))))
 
 (provide 'ekg-test)
+
+(ert-deftest test-ekg-truncate-at-word ()
+  "Test ekg-truncate-at with word-based truncation."
+  (let ((ekg-truncation-method 'word)
+        (english-text "This is a sample English text for testing truncation.")
+        (chinese-text "这是一段用于测试截断的示例文本"))
+    (should (string= (ekg-truncate-at english-text 4) "This is a sample…"))
+    (should (string= (ekg-truncate-at english-text 9) english-text))
+    (should (string= (ekg-truncate-at english-text 10) english-text))
+    ;; forward-word treats the entire chinese_text as one word if no spaces
+    (should (string= (ekg-truncate-at chinese-text 1) chinese-text))
+    (should (string= (ekg-truncate-at chinese-text 0) "…"))))
+
+(ert-deftest test-ekg-truncate-at-character ()
+  "Test ekg-truncate-at with character-based truncation."
+  (let ((ekg-truncation-method 'character)
+        (english-text "This is a sample English text for testing truncation.")
+        (chinese-text "这是一段用于测试截断的示例文本"))
+    (should (string= (ekg-truncate-at english-text 10) "This is a …"))
+    (should (string= (ekg-truncate-at english-text 46) english-text))
+    (should (string= (ekg-truncate-at english-text 50) english-text))
+    (should (string= (ekg-truncate-at chinese-text 5) "这是一段用…"))
+    (should (string= (ekg-truncate-at chinese-text 15) chinese-text))
+    (should (string= (ekg-truncate-at chinese-text 20) chinese-text))))
+
+(ert-deftest test-ekg-embedding-text-selector-initial ()
+  "Test ekg-embedding-text-selector-initial with both truncation methods."
+  (let ((short-english "Short English.") ;; 2 words, 15 chars
+        (short-chinese "简短中文测试")      ;; 4 chars (effectively 4 words for char mode, 1 for word mode)
+        ;; Target words for embedding: floor(8191/1.5) = 5460
+        ;; Target chars for embedding: floor(8191/1.0) = 8191
+        (long-english (apply #'concat (make-list 3000 "word "))) ;; 3000 words
+        (long-chinese (make-string 7000 '(?中))))               ;; 7000 chars
+
+    ;; Test word-based selection
+    (setq ekg-truncation-method 'word)
+    (should (string= (ekg-embedding-text-selector-initial short-english) short-english))
+    (should (string= (ekg-embedding-text-selector-initial short-chinese) short-chinese)) ;; treated as 1 word
+    (should (string= (ekg-embedding-text-selector-initial long-english) long-english)) ;; 3000 words < 5460 words
+
+    ;; Test character-based selection
+    (setq ekg-truncation-method 'character)
+    (should (string= (ekg-embedding-text-selector-initial short-english) short-english))
+    (should (string= (ekg-embedding-text-selector-initial short-chinese) short-chinese))
+    (should (string= (ekg-embedding-text-selector-initial long-chinese) long-chinese)) ;; 7000 chars < 8191 chars
+
+    ;; Test actual truncation for embeddings by exceeding limits
+    (let ((very-long-chinese (make-string 9000 '(?测)))) ;; 9000 chars > 8191 chars
+      (setq ekg-truncation-method 'character)
+      (let ((selected-text (ekg-embedding-text-selector-initial very-long-chinese)))
+        ;; Check that it's truncated, and also that it's truncated to the target char count
+        (should (< (length selected-text) (length very-long-chinese)))
+        (should (= (length selected-text) 8191))))
+
+    (let ((very-long-english (apply #'concat (make-list 6000 "word ")))) ;; 6000 words > 5460 words
+       (setq ekg-truncation-method 'word)
+       (let ((selected-text (ekg-embedding-text-selector-initial very-long-english)))
+         (should (< (ekg-test-count-words-in-string selected-text) 6000))
+         ;; This assertion might be tricky due to how forward-word handles end of buffer
+         ;; and potential addition of "..." if that's part of the selector's behavior.
+         ;; The selector itself doesn't add "...", it just substrings.
+         ;; The primary check is that fewer words are returned than originally present.
+         (should (= (ekg-test-count-words-in-string selected-text) 5460))))
+))
 
 ;;; ekg-test.el ends here

--- a/ekg.el
+++ b/ekg.el
@@ -698,7 +698,7 @@ unchanged."
     (cond
      ((eq ekg-truncation-method 'word)
       (cl-loop with i = 0 while (and (< i num)
-                                     (forward-word 1)) ; Ensure forward-word moves by 1 word
+                                     (forward-word 1))
                do (cl-incf i)))
      ((eq ekg-truncation-method 'character)
       (goto-char (min (point-max) (+ (point-min) num)))))

--- a/ekg.el
+++ b/ekg.el
@@ -698,13 +698,19 @@ unchanged."
     (cond
      ((eq ekg-truncation-method 'word)
       (cl-loop with i = 0 while (and (< i num)
-                                     (forward-word 1))
-               do (cl-incf i)))
+                                     (skip-syntax-forward "w")
+                                     (skip-syntax-forward "._-"))
+               do (cl-incf i))
+      ;; Move back to the end of the last word/character
+      (skip-syntax-backward "-"))
      ((eq ekg-truncation-method 'character)
       (goto-char (min (point-max) (+ (point-min) num)))))
-    (when (< (point) (point-max))
-      (insert "…")
-      (delete-region (point) (point-max)))
+    (when (< (point) (save-excursion
+                       (goto-char (point-max))
+                       (skip-syntax-backward "-")
+                       (point)))
+      (insert "…"))
+    (delete-region (point) (point-max))
     (buffer-string)))
 
 


### PR DESCRIPTION
Introduces a new customizable variable `ekg-truncation-method` that allows you to select the method for text truncation. This can be set to 'word' (default) or 'character'.

This change addresses issue #205 (from the original repository ahyatt/ekg) where word-based truncation is not suitable for Asian languages that do not use spaces for word separation.

Modifications:
- Added `defcustom ekg-truncation-method` in `ekg.el`.
- Updated `ekg-truncate-at` in `ekg.el` to respect `ekg-truncation-method`, interpreting the `num` argument as words or characters accordingly.
- Updated `ekg-embedding-text-selector-initial` in `ekg-embedding.el` to also respect `ekg-truncation-method` for selecting text for embeddings.
- Added ERT tests in `ekg-test.el` to cover both word and character-based truncation for the modified functions.
- Updated `doc/ekg.org` to document the new variable and its usage, particularly for Asian languages. Docstrings for modified functions were also updated.

This provides more flexible text handling for display and embedding generation, catering to a broader range of languages.

This is fixing the incompatibility with Asian languages mentioned in   https://github.com/ahyatt/ekg/issues/205, but doesn't fix all the language tokenization variance.