### PR TITLE
Remove extra move to end of buffer in ekg-edit

### DIFF
--- a/ekg.el
+++ b/ekg.el
@@ -1520,7 +1520,6 @@ TAG can be nil and the user will be prompted for the tag."
                ekg-notes-display-images)
           (org-redisplay-inline-images)))
     (set-buffer-modified-p nil)
-    (goto-char (point-min))
     (pop-to-buffer buf)))
 
 (defun ekg--save-note-in-buffer ()


### PR DESCRIPTION
I don't remember why I added this, but we already move to the end of the buffer earlier in `ekg-edit`, so there's no point in doing it again after the function tags apply.

This should fix https://github.com/ahyatt/ekg/issues/214