### PR TITLE
Add list of hidden tags that ekg-agent appends to

### DIFF
--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -764,7 +764,7 @@ to the =ekg-hidden-tags= list. Notes containing any of these tags will not appea
 in standard note lists unless that specific tag is explicitly searched for.
 
 By default, tags like =ekg-draft-tag= and =ekg-trash-tag= are already treated as
-hidden. Other modules, such as `ekg-agent`, use this list to hide internal
+hidden. Other modules, such as =ekg-agent=, use this list to hide internal
 metadata notes.
 
 ** Text Truncation Method
@@ -1193,7 +1193,7 @@ processing, you may not want to use this.
 :END:
 The =ekg-auto-save= module is useful for users who enter longer notes, so that the notes are protected against accidentally killing the buffer, or emacs crashing, or any similar problem.  It is designed to work similarly to the built-in auto-save functionality, and has it's own variables that default to the auto-save equivalent.  So, for example, there is ~ekg-auto-save-timeout~, which defaults to the value of ~auto-save-timeout~.
 
-To start using this, you need to require the module and turn on =ekg-auto-save-mode= in the =ekg-edit-mode` and =ekg-capture-mode=.  For example:
+To start using this, you need to require the module and turn on =ekg-auto-save-mode= in the =ekg-edit-mode= and =ekg-capture-mode=.  For example:
 #+begin_src emacs-lisp
 (require 'ekg-auto-save)
 (add-hook 'ekg-capture-mode-hook 'ekg-auto-save-mode)

--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -737,7 +737,7 @@ command =ekg-global-rename-tag= can quickly rename one tag to another globally
 across the database, so all tags with the old tag now have the new tag.  (Note
 that the new tag may already exist, in which case this operation cannot be
 easily undone.)
-* Customizing ekg with hooks
+* Customizing ekg
 You can customize the behavior of ekg in a number of ways.
 
 First, you can create your own schema to store your own data.  The hook
@@ -758,10 +758,19 @@ The ~ekg-note-add-tag-hook~ is called when adding a tag, either via the initial
 tags added to a new note, or tags added after completing a new tag in the note's
 property list.
 
+** Hidden Tags
+EKG allows modules or users to hide certain tags from normal view by adding them
+to the =ekg-hidden-tags= list. Notes containing any of these tags will not appear
+in standard note lists unless that specific tag is explicitly searched for.
+
+By default, tags like =ekg-draft-tag= and =ekg-trash-tag= are already treated as
+hidden. Other modules, such as `ekg-agent`, use this list to hide internal
+metadata notes.
+
 ** Text Truncation Method
 EKG provides a way to customize how text is truncated for display (e.g., in note
 lists or inline transclusions) and for generating embeddings. This is controlled
-by the `ekg-truncation-method` variable.
+by the =ekg-truncation-method= variable.
 
 You can set =ekg-truncation-method= to one of the following values:
 - ='word= (default): Text is truncated based on word counts. This is suitable
@@ -1280,6 +1289,10 @@ current note. This is an agentic version of =ekg-llm-send-and-append-note=. The
 agent can use tools to research your other notes and decide whether to append
 information to your note or replace it entirely. As with other LLM commands, a
 prefix argument allows you to edit the instructions sent to the agent.
+
+Internal agent notes (using the =agent/self-info= and =agent/status-instruct=
+tags) are hidden from normal view by being added to =ekg-hidden-tags=. You can
+view these notes specifically with =ekg-show-agent-notes=.
 
 You can also have the agent run automatically every day.  To do this, customize
 ~ekg-agent-daily-time~ to your preferred time (default is "09:00"), and then run:

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -1237,7 +1237,7 @@ to the @samp{ekg-hidden-tags} list. Notes containing any of these tags will not 
 in standard note lists unless that specific tag is explicitly searched for.
 
 By default, tags like @samp{ekg-draft-tag} and @samp{ekg-trash-tag} are already treated as
-hidden. Other modules, such as `ekg-agent`, use this list to hide internal
+hidden. Other modules, such as @samp{ekg-agent}, use this list to hide internal
 metadata notes.
 
 @node Text Truncation Method
@@ -1717,7 +1717,7 @@ processing, you may not want to use this.
 
 The @samp{ekg-auto-save} module is useful for users who enter longer notes, so that the notes are protected against accidentally killing the buffer, or emacs crashing, or any similar problem.  It is designed to work similarly to the built-in auto-save functionality, and has it's own variables that default to the auto-save equivalent.  So, for example, there is @code{ekg-auto-save-timeout}, which defaults to the value of @code{auto-save-timeout}.
 
-To start using this, you need to require the module and turn on @samp{ekg-auto-save-mode} in the @samp{ekg-edit-mode` and =ekg-capture-mode}.  For example:
+To start using this, you need to require the module and turn on @samp{ekg-auto-save-mode} in the @samp{ekg-edit-mode} and @samp{ekg-capture-mode}.  For example:
 @lisp
 (require 'ekg-auto-save)
 (add-hook 'ekg-capture-mode-hook 'ekg-auto-save-mode)

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -53,7 +53,7 @@ and in the git repository, which is at @uref{https://github.com/ahyatt/ekg}.
 * Importing from org-roam::
 * Backups::
 * Database maintenance::
-* Customizing ekg with hooks::
+* Customizing ekg::
 * Integration with ekg::
 * Extras::
 * Design::
@@ -107,8 +107,9 @@ Viewing tags or notes
 * Commands in the notes buffer::
 * Customizing note display in @samp{ekg-notes-mode}::
 
-Customizing ekg with hooks
+Customizing ekg
 
+* Hidden Tags::
 * Text Truncation Method::
 
 Extras
@@ -1200,8 +1201,8 @@ across the database, so all tags with the old tag now have the new tag.  (Note
 that the new tag may already exist, in which case this operation cannot be
 easily undone.)
 
-@node Customizing ekg with hooks
-@chapter Customizing ekg with hooks
+@node Customizing ekg
+@chapter Customizing ekg
 
 You can customize the behavior of ekg in a number of ways.
 
@@ -1224,15 +1225,27 @@ tags added to a new note, or tags added after completing a new tag in the note's
 property list.
 
 @menu
+* Hidden Tags::
 * Text Truncation Method::
 @end menu
+
+@node Hidden Tags
+@section Hidden Tags
+
+EKG allows modules or users to hide certain tags from normal view by adding them
+to the @samp{ekg-hidden-tags} list. Notes containing any of these tags will not appear
+in standard note lists unless that specific tag is explicitly searched for.
+
+By default, tags like @samp{ekg-draft-tag} and @samp{ekg-trash-tag} are already treated as
+hidden. Other modules, such as `ekg-agent`, use this list to hide internal
+metadata notes.
 
 @node Text Truncation Method
 @section Text Truncation Method
 
 EKG provides a way to customize how text is truncated for display (e.g., in note
 lists or inline transclusions) and for generating embeddings. This is controlled
-by the `ekg-truncation-method` variable.
+by the @samp{ekg-truncation-method} variable.
 
 You can set @samp{ekg-truncation-method} to one of the following values:
 @itemize
@@ -1808,6 +1821,10 @@ current note. This is an agentic version of @samp{ekg-llm-send-and-append-note}.
 agent can use tools to research your other notes and decide whether to append
 information to your note or replace it entirely. As with other LLM commands, a
 prefix argument allows you to edit the instructions sent to the agent.
+
+Internal agent notes (using the @samp{agent/self-info} and @samp{agent/status-instruct}
+tags) are hidden from normal view by being added to @samp{ekg-hidden-tags}. You can
+view these notes specifically with @samp{ekg-show-agent-notes}.
 
 You can also have the agent run automatically every day.  To do this, customize
 @code{ekg-agent-daily-time} to your preferred time (default is "09:00"), and then run:

--- a/ekg-agent.el
+++ b/ekg-agent.el
@@ -51,6 +51,9 @@
   :type 'string
   :group 'ekg-agent)
 
+(add-to-list 'ekg-hidden-tags ekg-agent-self-info-tag)
+(add-to-list 'ekg-hidden-tags ekg-agent-self-instruct-tag)
+
 (defcustom ekg-agent-context-func #'ekg-agent-starting-context
   "Function that returns the starting information for an ekg agent.
 
@@ -397,6 +400,11 @@ Context (current note and last 10 notes with same tags):\n"
 ;; Redefine the keys, take the binding over from ekg-llm.
 (define-key ekg-capture-mode-map (kbd "C-c .") #'ekg-agent-note-response)
 (define-key ekg-edit-mode-map (kbd "C-c .") #'ekg-agent-note-response)
+
+(defun ekg-show-agent-notes ()
+  "Show notes with agent internal tags."
+  (interactive)
+  (ekg-show-notes-with-any-tags (list ekg-agent-self-info-tag ekg-agent-self-instruct-tag)))
 
 (provide 'ekg-agent)
 


### PR DESCRIPTION
This is so that users don't need to see the agent's notes to itself.