### PR TITLE
Fix script escapification, create tool and read tool output

### DIFF
--- a/agent_tools/ekg-read
+++ b/agent_tools/ekg-read
@@ -136,15 +136,11 @@ case $MODE in
         done
         TAGS_ELISP="${TAGS_ELISP% })"
 
-        ELISP_EXPR="(princ (progn
-          (require 'ekg-agent)
-          (ekg-agent-read-notes :tags '$TAGS_ELISP :num $NUM :max-words $MAX_WORDS)))"
+        READ_EXPR="(ekg-agent-read-notes :tags '$TAGS_ELISP :num $NUM :max-words $MAX_WORDS)"
         ;;
 
     id)
-        ELISP_EXPR="(princ (progn
-          (require 'ekg-agent)
-          (ekg-agent-read-notes :note-id $NOTE_ID)))"
+        READ_EXPR="(ekg-agent-read-notes :note-id $NOTE_ID)"
         ;;
 
     semantic)
@@ -152,9 +148,7 @@ case $MODE in
         SEARCH_ELISP="${SEMANTIC_SEARCH//\\/\\\\}"
         SEARCH_ELISP="${SEARCH_ELISP//\"/\\\"}"
 
-        ELISP_EXPR="(princ (progn
-          (require 'ekg-agent)
-          (ekg-agent-read-notes :semantic-search \"$SEARCH_ELISP\" :num $NUM :max-words $MAX_WORDS)))"
+        READ_EXPR="(ekg-agent-read-notes :semantic-search \"$SEARCH_ELISP\" :num $NUM :max-words $MAX_WORDS)"
         ;;
 
     text)
@@ -162,15 +156,11 @@ case $MODE in
         SEARCH_ELISP="${TEXT_SEARCH//\\/\\\\}"
         SEARCH_ELISP="${SEARCH_ELISP//\"/\\\"}"
 
-        ELISP_EXPR="(princ (progn
-          (require 'ekg-agent)
-          (ekg-agent-read-notes :text-search \"$SEARCH_ELISP\" :num $NUM :max-words $MAX_WORDS)))"
+        READ_EXPR="(ekg-agent-read-notes :text-search \"$SEARCH_ELISP\" :num $NUM :max-words $MAX_WORDS)"
         ;;
 
     latest)
-        ELISP_EXPR="(princ (progn
-          (require 'ekg-agent)
-          (ekg-agent-read-notes :latest t :num $NUM :max-words $MAX_WORDS)))"
+        READ_EXPR="(ekg-agent-read-notes :latest t :num $NUM :max-words $MAX_WORDS)"
         ;;
 esac
 
@@ -180,6 +170,13 @@ if [[ -n "$DAEMON_NAME" ]]; then
     EMACSCLIENT_CMD+=" -s $DAEMON_NAME"
 fi
 
+# Base64-encode the JSON to avoid emacsclient protocol escaping issues.
+# emacsclient --eval interprets \n in output as literal newlines, which can
+# corrupt output containing JSON with embedded newlines.
+ELISP_EXPR="(progn
+  (require 'ekg-agent)
+  (base64-encode-string (encode-coding-string $READ_EXPR 'utf-8) t))"
+
 # Execute via emacsclient
 if ! OUTPUT=$($EMACSCLIENT_CMD --eval "$ELISP_EXPR" 2>&1); then
     echo "Error: Failed to read notes. Is the Emacs daemon running?" >&2
@@ -188,10 +185,5 @@ if ! OUTPUT=$($EMACSCLIENT_CMD --eval "$ELISP_EXPR" 2>&1); then
     exit 1
 fi
 
-# Output the JSON
-# emacsclient --eval always returns the Elisp printed representation, which means:
-# - The string is wrapped in double quotes
-# - Internal quotes are escaped as \"
-# - Backslashes are escaped as \\
-# We need to strip the outer quotes and unescape: \\\\ -> \\ and \" -> "
-echo "$OUTPUT" | sed 's/^"//; s/"$//' | sed 's/\\\\\\\\/\\\\/g; s/\\"/"/g'
+# Strip outer quotes from emacsclient output, then base64-decode
+echo "$OUTPUT" | sed 's/^"//; s/"$//' | base64 --decode

--- a/agent_tools/ekg-tags
+++ b/agent_tools/ekg-tags
@@ -126,9 +126,12 @@ if [[ -n "$REGEX" ]]; then
     (setq tags (seq-filter (lambda (tag) (string-match-p \"$escaped\" tag)) tags))"
 fi
 
-# Output as JSON array
+# Output as base64-encoded JSON array to avoid emacsclient protocol issues
 ELISP+="
-    (princ (concat \"[\" (mapconcat (lambda (tag) (format \"\\\"%s\\\"\" tag)) (sort tags #'string<) \",\") \"]\"))))"
+    (base64-encode-string
+     (encode-coding-string
+      (concat \"[\" (mapconcat (lambda (tag) (format \"\\\"%s\\\"\" tag)) (sort tags #'string<) \",\") \"]\")
+      'utf-8) t)))"
 
 # Build emacsclient command
 EMACSCLIENT_CMD="emacsclient"
@@ -143,5 +146,5 @@ if ! OUTPUT=$($EMACSCLIENT_CMD --eval "$ELISP" 2>&1); then
     exit 1
 fi
 
-# Clean up emacsclient output (strip outer quotes, unescape)
-echo "$OUTPUT" | sed 's/^"//; s/"$//' | sed 's/\\\\\\\\/\\\\/g; s/\\"/"/g'
+# Strip outer quotes from emacsclient output, then base64-decode
+echo "$OUTPUT" | sed 's/^"//; s/"$//' | base64 --decode

--- a/ekg-agent.el
+++ b/ekg-agent.el
@@ -288,8 +288,7 @@ but we'll only get strings from the LLM."
                                (unless (member mode '("org-mode" "markdown-mode" "text-mode"))
                                  (error "Unsupported mode: %s" mode))
                                ;; Use ekg-agent-add-note for consistency (includes auto-tags)
-                               (let ((note (ekg-agent-add-note content (append tags nil) mode)))
-                                 (format "Created note with ID %s" (ekg-note-id note)))))
+                               (format "Created note with ID %s" (ekg-agent-add-note content (append tags nil) mode))))
                  :name "create_note"
                  :description "Create a new note with specified tags and content."
                  :args `((:name "tags" :type array :items (:type string)
@@ -1534,7 +1533,8 @@ If MAX-WORDS is specified, truncate the text to that many words."
       (mode . ,(symbol-name (ekg-note-mode note)))
       (tags . ,(ekg-note-tags note))
       (creation_time . ,(ekg-note-creation-time note))
-      (modified_time . ,(ekg-note-modified-time note)))))
+      (modified_time . ,(ekg-note-modified-time note))
+      (properties . ,(ekg-note-properties note)))))
 
 (defun ekg-agent--notes-to-json (notes &optional max-words)
   "Convert list of NOTES to a JSON array string.

--- a/ekg.el
+++ b/ekg.el
@@ -568,6 +568,8 @@ Draft notes are not returned, unless TAGS contains the draft tag."
 If the ID does not exist, create a new note with that ID."
   (ekg-connect)
   (let* ((v (triples-get-subject ekg-db id))
+         (stored-types (triples-get-types ekg-db id))
+         (core-types '(text time-tracked inline titled tagged))
          (inlines (mapcar (lambda (iid)
                             (let ((iv (triples-get-type ekg-db iid
                                                         'inline)))
@@ -576,7 +578,20 @@ If the ID does not exist, create a new note with that ID."
                                                          (plist-get iv :command)
                                                          (plist-get iv :args))
                                                :type (plist-get iv :type))))
-                          (plist-get v :text/inlines))))
+                          (plist-get v :text/inlines)))
+         ;; Query extension types not already returned by triples-get-subject,
+         ;; to pick up virtual reversed properties like org/children.
+         (extra-props
+          (mapcan (lambda (type)
+                    (unless (or (memq type stored-types)
+                                (memq type core-types))
+                      (let ((type-data (triples-get-type ekg-db id type)))
+                        (when type-data
+                          (cl-loop for (k v) on type-data by #'cddr
+                                   nconc (list (intern (format ":%s/%s" type
+                                                               (substring (symbol-name k) 1)))
+                                               v))))))
+                  (ekg-note-cotypes))))
     (make-ekg-note :id id
                    :text (plist-get v :text/text)
                    :mode (plist-get v :text/mode)
@@ -584,17 +599,19 @@ If the ID does not exist, create a new note with that ID."
                    :tags (plist-get v :tagged/tag)
                    :creation-time (plist-get v :time-tracked/creation-time)
                    :modified-time (plist-get v :time-tracked/modified-time)
-                   :properties (map-into
-                                (map-filter
-                                 (lambda (plist-key _)
-                                   (not (member plist-key
-                                                '(:text/text
-                                                  :text/mode
-                                                  :text/inlines
-                                                  :tagged/tag
-                                                  :time-tracked/creation-time
-                                                  :time-tracked/modified-time)))) v)
-                                'plist))))
+                   :properties (append
+                                (map-into
+                                 (map-filter
+                                  (lambda (plist-key _)
+                                    (not (member plist-key
+                                                 '(:text/text
+                                                   :text/mode
+                                                   :text/inlines
+                                                   :tagged/tag
+                                                   :time-tracked/creation-time
+                                                   :time-tracked/modified-time)))) v)
+                                 'plist)
+                                extra-props))))
 
 (defun ekg-get-notes-with-title (title)
   "Get a list of note structs with TITLE."


### PR DESCRIPTION
The escapification in `ekg-read` and `ekg-tags` was incorrect, and is now fixed.

Return the maximal amount of information in `ekg.el`, and in `ekg-agent--note-to-alist`.

Also fix an error in `ekg-agent-tool-create-note`.