### PR TITLE
Splits ekg into separate packages to handle extra dependencies

### DIFF
--- a/doc/ekg.org
+++ b/doc/ekg.org
@@ -1206,8 +1206,10 @@ In the capture mode, this. is equivalent to saving periodically (to drafts).  In
 :END:
 ekg can export notes as denotes. Denote is a note taking and file
 naming tool. Primary reason for export is taking backup of your notes
-in a git backed repository. Import is in road map (PR is welcome). To
-export to denote, =ekg-denote= module is required.
+in a git backed repository. Import is in road map (PR is welcome).
+
+To export to denote, =ekg-denote= module is required, which is a separate package
+from ekg in MELPA.
 
 #+begin_src emacs-lisp
   (use-package ekg-denote
@@ -1270,6 +1272,16 @@ notes.  This agent can review your notes and org-mode agenda, searching across
 notes by embeddings or tags as appropriate, and proactively create new notes to
 help you, such as offering advice, pointing out connections, or suggesting
 resources.
+
+=ekg-agent= is a separate package from =ekg= and must be installed separately.
+
+#+begin_src emacs-lisp
+(use-package ekg-agent
+  :init
+  (setq ekg-agent-code-command "~/.local/bin/claude -p --dangerously-skip-permissions")
+  (add-to-list 'ekg-agent-extra-tools (list ekg-agent-tool-run-elisp
+                                            ekg-agent-tool-code)))
+#+end_src
 
 To use this module, you must have an LLM provider configured as described in the
 [[#llm][LLM]] section.  You can then load the agent:

--- a/doc/ekg.texi
+++ b/doc/ekg.texi
@@ -1735,8 +1735,10 @@ In the capture mode, this. is equivalent to saving periodically (to drafts).  In
 
 ekg can export notes as denotes. Denote is a note taking and file
 naming tool. Primary reason for export is taking backup of your notes
-in a git backed repository. Import is in road map (PR is welcome). To
-export to denote, @samp{ekg-denote} module is required.
+in a git backed repository. Import is in road map (PR is welcome).
+
+To export to denote, @samp{ekg-denote} module is required, which is a separate package
+from ekg in MELPA@.
 
 @lisp
 (use-package ekg-denote
@@ -1807,6 +1809,16 @@ notes.  This agent can review your notes and org-mode agenda, searching across
 notes by embeddings or tags as appropriate, and proactively create new notes to
 help you, such as offering advice, pointing out connections, or suggesting
 resources.
+
+@samp{ekg-agent} is a separate package from @samp{ekg} and must be installed separately.
+
+@lisp
+(use-package ekg-agent
+  :init
+  (setq ekg-agent-code-command "~/.local/bin/claude -p --dangerously-skip-permissions")
+  (add-to-list 'ekg-agent-extra-tools (list ekg-agent-tool-run-elisp
+                                            ekg-agent-tool-code)))
+@end lisp
 
 To use this module, you must have an LLM provider configured as described in the
 @ref{LLM} section.  You can then load the agent:

--- a/ekg-agent-pkg.el
+++ b/ekg-agent-pkg.el
@@ -5,7 +5,7 @@
 
 ;;; Code:
 
-(define-package "ekg-agent" "20260305"
+(define-package "ekg-agent" "0.0.1"
   "Agent tools for ekg."
   '((ekg "20260305")
     (async "20251005.634")))

--- a/ekg-agent-pkg.el
+++ b/ekg-agent-pkg.el
@@ -1,0 +1,14 @@
+;;; ekg-agent-pkg.el --- Package definition for ekg-agent -*- no-byte-compile: t -*-
+
+;;; Commentary:
+;;; This defines the package for ekg-agent.
+
+;;; Code:
+
+(define-package "ekg-agent" "20260305"
+  "Agent tools for ekg."
+  '((ekg "20260305")
+    (async "20251005.634")))
+
+(provide 'ekg-agent-pkg)
+;;; ekg-agent-pkg.el ends here

--- a/ekg-agent.el
+++ b/ekg-agent.el
@@ -6,6 +6,7 @@
 ;; Homepage: https://github.com/ahyatt/ekg
 ;; Package-Requires: ((ekg "0.8.0") async)
 ;; Keywords: outlines, hypermedia
+;; Version: 0.0.1
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
 ;; This program is free software; you can redistribute it and/or

--- a/ekg-agent.el
+++ b/ekg-agent.el
@@ -4,6 +4,7 @@
 
 ;; Author: Andrew Hyatt <ahyatt@gmail.com>
 ;; Homepage: https://github.com/ahyatt/ekg
+;; Package-Requires: ((ekg "0.8.0") async)
 ;; Keywords: outlines, hypermedia
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -31,6 +32,7 @@
 (require 'llm-vertex)
 (require 'ekg-llm)
 (require 'ekg-embedding)
+(require 'ekg-org)
 (require 'seq)
 (require 'json)
 (require 'subr-x)
@@ -1634,6 +1636,179 @@ notes from ekg."
                                      :latest latest
                                      :num num)))
     (ekg-agent--notes-to-json notes max-words)))
+
+;; ekg-org integration
+
+(defun ekg-agent-org--tool-add-item (title content tags parent-id status deadline scheduled)
+  "Add a new org task item to EKG.
+
+TITLE is the task title.
+CONTENT is the task content/description.
+TAGS is a list of additional tags.
+PARENT-ID is the parent task ID (nil for no parent)
+STATUS is the task status (will be converted to uppercase).
+DEADLINE is the deadline timestamp string (ignored if empty).
+SCHEDULED is the scheduled timestamp string (ignored if empty)."
+  (ekg-agent--with-error-as-text
+    (let* ((note (ekg-note-create :text content
+                                  :tags (append (list ekg-org-task-tag) tags
+                                                (when (and status (not (string-empty-p status)))
+                                                  (list (concat ekg-org-state-tag-prefix (downcase status)))))
+                                  :properties (list :titled/title (list title)))))
+      ;; Handle parent ID
+      (when (and parent-id (not (equal parent-id 0)) (not (string-empty-p (format "%s" parent-id))))
+        (setf (ekg-note-properties note) (plist-put (ekg-note-properties note) :org/parent parent-id)))
+      ;; Handle deadline
+      (when (and deadline (not (string-empty-p deadline)))
+        (setf (ekg-note-properties note) (plist-put (ekg-note-properties note) :org/deadline (ekg-org--to-timestamp deadline))))
+      ;; Handle scheduled
+      (when (and scheduled (not (string-empty-p scheduled)))
+        (setf (ekg-note-properties note) (plist-put (ekg-note-properties note) :org/scheduled (ekg-org--to-timestamp scheduled))))
+      ;; Save the note
+      (ekg-save-note note)
+      (format "Added note with ID %s" (ekg-note-id note)))))
+
+(defconst ekg-agent-org-tool-add-task
+  (llm-make-tool
+   :function #'ekg-agent-org--tool-add-item
+   :name "add_org_item"
+   :description "Add a new org-mode task item"
+   :args
+   '((:name "title" :type string :description "The title/headline of the task" :require t)
+     (:name "content" :type string :description "The content/description of the task" :required t)
+     (:name "tags" :type array :items (:type string)
+            :description "Additional tags for the task (org tags and agent tags will be added automatically)")
+     (:name "parent_id" :type integer :description "The parent task ID if exists")
+     (:name "status" :type string :description "The task status (TODO, DONE, etc.), will default to TODO if not set")
+     (:name "deadline" :type string :description "The deadline timestamp in ISO 8601 format")
+     (:name "scheduled" :type string :description "The scheduled timestamp in ISO 8601 format"))))
+
+(defun ekg-agent-org--tool-set-status (id status)
+  "Set the status of an org task item.
+
+ID is the note ID.
+STATUS is the new status (will be converted to uppercase)."
+  (ekg-agent--with-error-as-text
+    (let ((note (ekg-get-note-with-id id)))
+      (unless note
+        (error "No note found with ID %s" id))
+      (setf (ekg-note-tags note)
+            (cons
+             (concat ekg-org-state-tag-prefix (downcase status))
+             (seq-remove
+              (lambda (tag) (string-prefix-p ekg-org-state-tag-prefix tag))
+              (ekg-note-tags note))))
+      (ekg-save-note note)
+      (format "Set status of note ID %s to %s" id status))))
+
+(defconst ekg-agent-org-tool-set-status
+  (llm-make-tool
+   :function #'ekg-agent-org--tool-set-status
+   :name "set_org_item_status"
+   :description "Set the status of an org-mode task item.  Use this when you want to change the status of an existing task, for example setting it to DONE when completing it, or marking it WAITING if it's on hold."
+   :args
+   '((:name "id" :type integer :description "The ID of the task item" :required t)
+     (:name "status" :type string :description "The new status of the task (TODO, DONE, etc.)" :required t))))
+
+(defun ekg-agent-org--tool-list-items (&optional state)
+  "List all org task items.
+
+STATE if non-nil, filter by status (e.g., \"TODO\", \"DONE\").
+Returns text in Org format, as if they were in an Org file."
+  (ekg-agent--with-error-as-text
+    (let ((result (ekg-org-generate-org-content
+                   nil (when state
+                         (lambda (note)
+                           (string-equal
+                            (downcase state)
+                            (downcase (ekg-org--state note))))))))
+      (if (string-empty-p result)
+          (if state
+              (format "No org items found with state %s." state)
+            "No org items found.")
+        result))))
+
+(defconst ekg-agent-org-tool-list-items
+  (llm-make-tool
+   :function #'ekg-agent-org--tool-list-items
+   :name "list_org_items"
+   :description "Return all matching org-mode task items as an Org formatted string."
+   :args
+   '((:name "state" :type string
+            :description "Filter tasks by state (TODO, DONE, etc.)"))))
+
+(defun ekg-agent-org-plan-task ()
+  "Plan the current task and add the plan as child tasks using the agent."
+  (interactive)
+  (let* ((ekg-note (ekg-current-note-or-error-expanded))
+         (parent-id (ekg-note-id ekg-note))
+         (parent-note (ekg-get-note-with-id parent-id))
+         (question (format "Given the task '%s', create a plan to accomplish it by creating subtasks using the tool to add ekg org tasks or add information to existing ekg note tasks. The parent ekg note id is '%s'."
+                           (ekg-org--note-title parent-note)
+                           parent-id)))
+    (ekg-agent-ask-with-note question parent-id (list ekg-agent-org-tool-add-task))))
+
+(defun ekg-agent-org-run-task ()
+  "Execute the current org task autonomously using the agent.
+The agent receives the full org hierarchy as context (current task,
+parent, grandparent, etc.) and instructions to complete the task.
+When finished, the agent sets the task status (typically DONE),
+which ends the agent session.  No human input is required."
+  (interactive)
+  (let* ((ekg-note (ekg-current-note-or-error-expanded))
+         (task-id (ekg-note-id ekg-note))
+         (note (ekg-get-note-with-id task-id))
+         (hierarchy (ekg-org--get-hierarchy note))
+         (hierarchy-text (ekg-org--hierarchy-to-text hierarchy))
+         (title (or (ekg-org--note-title note) "(untitled)"))
+         (children (ekg-org-get-child-notes-of-id task-id))
+         (children-text (when children
+                          (concat "\n\nChild tasks:\n"
+                                  (mapconcat
+                                   (lambda (child)
+                                     (format "  - [%s] %s (id: %s)"
+                                             (condition-case nil (ekg-org--state child) (error "UNKNOWN"))
+                                             (or (ekg-org--note-title child) "(untitled)")
+                                             (ekg-note-id child)))
+                                   children "\n"))))
+         (prompt-notes (ekg-get-notes-cotagged-with-tags
+                        (ekg-note-tags note) ekg-llm-prompt-tag))
+         (prompt-context (when prompt-notes
+                           (concat "\n\nPrompt instructions from co-tagged notes:\n"
+                                   (mapconcat (lambda (n)
+                                                (string-trim
+                                                 (substring-no-properties
+                                                  (ekg-display-note-text n nil 'plaintext))))
+                                              prompt-notes "\n"))))
+         (context (concat
+                   "You are executing an org task autonomously. Here is the full task hierarchy, "
+                   "from the root task down to the current task you must execute:\n\n"
+                   hierarchy-text
+                   (or children-text "")
+                   (or prompt-context "")
+                   "\n\n"
+                   (format "The current date and time is %s." (format-time-string "%F %R"))))
+         (question (concat
+                    (format "Execute the following task: '%s' (note id: %s).\n\n" title task-id)
+                    "Complete this task using the tools available to you. "
+                    "You should NOT ask the user for input. Work autonomously.\n\n"
+                    "When you are done, you MUST call the `set_org_item_status` tool to "
+                    "set this task's status (typically to DONE, or WAITING if blocked). "
+                    "Calling `set_org_item_status` will end your session.\n\n"
+                    "Before setting the status, use `display_result_in_popup` to tell the user what you did.")))
+    (ekg-agent--iterate (llm-make-chat-prompt
+                         question
+                         :context (concat (ekg-agent-instructions-intro) "\n\n" context)
+                         :tools (ekg-agent--tools
+                                 (list ekg-agent-tool-popup-result
+                                       ekg-agent-org-tool-add-task
+                                       ekg-agent-org-tool-set-status
+                                       ekg-agent-org-tool-list-items))
+                         :tool-options (make-llm-tool-options :tool-choice 'any))
+                        0
+                        (ekg-agent--make-status-callback)
+                        '("set_org_item_status")
+                        (ekg-agent--timeout-deadline))))
 
 (provide 'ekg-agent)
 

--- a/ekg-denote-pkg.el
+++ b/ekg-denote-pkg.el
@@ -5,7 +5,7 @@
 
 ;;; Code:
 
-(define-package "ekg-denote" "20260305"
+(define-package "ekg-denote" "1.0.0"
   "Denote integration for ekg."
   '((ekg "20260305")(denote "4.0.0")))
 

--- a/ekg-denote-pkg.el
+++ b/ekg-denote-pkg.el
@@ -1,0 +1,13 @@
+;;; ekg-denote-pkg.el --- Denote integration for ekg.  -*- no-byte-compile: t -*-
+
+;;; Commentary:
+;;; This defines the package for ekg-denote.
+
+;;; Code:
+
+(define-package "ekg-denote" "20260305"
+  "Denote integration for ekg."
+  '((ekg "20260305")(denote "4.0.0")))
+
+(provide 'ekg-denote-pkg)
+;;; ekg-denote-pkg.el ends here

--- a/ekg-denote.el
+++ b/ekg-denote.el
@@ -2,6 +2,13 @@
 
 ;; Copyright (c) 2024  Jay Rajput <jayrajput@gmail.com>
 
+;; Author: Jay Rajput <jayrajput@gmail.com>
+;; Homepage: https://github.com/ahyatt/ekg
+;; Package-Requires: ((ekg "0.7.0") (denote "4.0.0"))
+;; Keywords: outlines, hypermedia
+;; Version: 1.0.0
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as
 ;; published by the Free Software Foundation; either version 3 of the
@@ -27,7 +34,6 @@
 ;; ekg notes are trimmed to a configurable length before export.  Ekg
 ;; notes can have creation time within a second when trying to bulk
 ;; import org-roam files to ekg.
-;;
 
 
 (require 'ekg)

--- a/ekg-org-test.el
+++ b/ekg-org-test.el
@@ -22,6 +22,7 @@
 (require 'ert)
 (require 'ekg)
 (require 'ekg-org)
+(require 'ekg-agent)
 (require 'ekg-test-utils)
 
 (defun ekg-org-test-parse-out-id (result-string)
@@ -33,7 +34,7 @@
   "Test that a basic task is rendered correctly."
   (ekg-org-add-schema)
   (let* ((note-id (ekg-org-test-parse-out-id
-                   (ekg-org--agent-tool-add-item
+                   (ekg-agent-org--tool-add-item
                     "Test Task"
                     "This is a test task content."
                     '("tag1" "tag2")
@@ -58,7 +59,7 @@
   (ekg-org-add-schema)
   (let* ((deadline "2026-02-01 10:00")
          (scheduled "2026-01-31 09:00")
-         (note-result (ekg-org--agent-tool-add-item
+         (note-result (ekg-agent-org--tool-add-item
                        "Timed Task"
                        "Content"
                        nil
@@ -80,14 +81,14 @@
 (ekg-deftest ekg-org-test-hierarchy ()
   "Test that child tasks have correct parent relationship."
   (ekg-org-add-schema)
-  (let* ((parent-result (ekg-org--agent-tool-add-item
+  (let* ((parent-result (ekg-agent-org--tool-add-item
                          "Parent Task"
                          "Parent content"
                          nil nil "TODO" nil nil))
          ;; The result will have the integer ID as a substring, let's just parse it out.
          (parent-id (ekg-org-test-parse-out-id parent-result))
          ;; Add a child task
-         (child (ekg-org--agent-tool-add-item
+         (child (ekg-agent-org--tool-add-item
                  "Child Task"
                  "Child content"
                  nil parent-id "TODO" nil nil))
@@ -109,11 +110,11 @@
   "Test ekg-org-generate-org-content function."
   (ekg-org-add-schema)
   ;; Create multiple tasks
-  (let* ((task1-id (ekg-org--agent-tool-add-item
+  (let* ((task1-id (ekg-agent-org--tool-add-item
                     "Task One"
                     "First task content"
                     '("project1") nil "TODO" nil nil))
-         (task2-id (ekg-org--agent-tool-add-item
+         (task2-id (ekg-agent-org--tool-add-item
                     "Task Two"
                     "Second task content"
                     '("project2") nil "DONE" nil nil))
@@ -135,13 +136,13 @@
   (ekg-org-add-schema)
   ;; Create normal task
   (let* ((normal (ekg-org-test-parse-out-id
-                  (ekg-org--agent-tool-add-item
+                  (ekg-agent-org--tool-add-item
                    "Normal Task"
                    "Normal content"
                    nil nil "TODO" nil nil)))
          ;; Create archived task by adding archive tag
          (archived-id (ekg-org-test-parse-out-id
-                       (ekg-org--agent-tool-add-item
+                       (ekg-agent-org--tool-add-item
                         "Archived Task"
                         "Archived content"
                         (list ekg-org-archive-tag) nil "DONE" nil nil))))
@@ -163,13 +164,13 @@
 (ekg-deftest ekg-org-test-set-status ()
   "Test changing status of a task."
   (ekg-org-add-schema)
-  (let* ((note-result (ekg-org--agent-tool-add-item
+  (let* ((note-result (ekg-agent-org--tool-add-item
                        "Status Task"
                        "Content"
                        nil nil "TODO" nil nil))
          (note-id (ekg-org-test-parse-out-id note-result)))
     ;; Change status to DONE
-    (ekg-org--agent-tool-set-status note-id "DONE")
+    (ekg-agent-org--tool-set-status note-id "DONE")
     (let* ((note (ekg-get-note-with-id note-id))
            (rendered (ekg-org-task-to-string note)))
       ;; Verify status changed in rendered output
@@ -191,12 +192,12 @@
 (ekg-deftest ekg-org-test-list-items ()
   "Test listing tasks."
   (ekg-org-add-schema)
-  (ekg-org--agent-tool-add-item "Task 1" "C1" nil nil "TODO" nil nil)
-  (ekg-org--agent-tool-add-item "Task 2" "C2" nil nil "DONE" nil nil)
-  (ekg-org--agent-tool-add-item "Archived" "AC"
+  (ekg-agent-org--tool-add-item "Task 1" "C1" nil nil "TODO" nil nil)
+  (ekg-agent-org--tool-add-item "Task 2" "C2" nil nil "DONE" nil nil)
+  (ekg-agent-org--tool-add-item "Archived" "AC"
                                 (list ekg-org-archive-tag) nil "DONE" nil nil)
-  (let ((all (ekg-org--agent-tool-list-items))
-        (todos (ekg-org--agent-tool-list-items "TODO")))
+  (let ((all (ekg-agent-org--tool-list-items))
+        (todos (ekg-agent-org--tool-list-items "TODO")))
     ;; Normal listing should not include archived
     (should (= (ekg-org-test-count-tasks all) 2))
     (should (= (ekg-org-test-count-tasks todos) 1))
@@ -207,7 +208,7 @@
   (ekg-org-add-schema)
   (let* ((note-id
           (ekg-org-test-parse-out-id
-           (ekg-org--agent-tool-add-item
+           (ekg-agent-org--tool-add-item
             "Tagged Task"
             "Content with tags"
             '("custom-tag" "project/test")

--- a/ekg-org.el
+++ b/ekg-org.el
@@ -29,7 +29,6 @@
 (require 'seq)
 (require 'ekg)
 (require 'llm)
-(require 'ekg-agent)
 
 ;; Forward declarations for variables defined later in this file.
 (defvar ekg-org-tool-add-task)
@@ -230,79 +229,6 @@ Each level is indented to show the nesting structure."
          result))
      hierarchy "")))
 
-(defun ekg-org-agent-plan-task ()
-  "Plan the current task and add the plan as child tasks using the agent."
-  (interactive)
-  (let* ((ekg-note (ekg-current-note-or-error-expanded))
-         (parent-id (ekg-note-id ekg-note))
-         (parent-note (ekg-get-note-with-id parent-id))
-         (question (format "Given the task '%s', create a plan to accomplish it by creating subtasks using the tool to add ekg org tasks or add information to existing ekg note tasks. The parent ekg note id is '%s'."
-                           (ekg-org--note-title parent-note)
-                           parent-id)))
-    (ekg-agent-ask-with-note question parent-id (list ekg-org-tool-add-task))))
-
-(defun ekg-org-agent-run-task ()
-  "Execute the current org task autonomously using the agent.
-The agent receives the full org hierarchy as context (current task,
-parent, grandparent, etc.) and instructions to complete the task.
-When finished, the agent sets the task status (typically DONE),
-which ends the agent session.  No human input is required."
-  (interactive)
-  (let* ((ekg-note (ekg-current-note-or-error-expanded))
-         (task-id (ekg-note-id ekg-note))
-         (note (ekg-get-note-with-id task-id))
-         (hierarchy (ekg-org--get-hierarchy note))
-         (hierarchy-text (ekg-org--hierarchy-to-text hierarchy))
-         (title (or (ekg-org--note-title note) "(untitled)"))
-         (children (ekg-org-get-child-notes-of-id task-id))
-         (children-text (when children
-                          (concat "\n\nChild tasks:\n"
-                                  (mapconcat
-                                   (lambda (child)
-                                     (format "  - [%s] %s (id: %s)"
-                                             (condition-case nil (ekg-org--state child) (error "UNKNOWN"))
-                                             (or (ekg-org--note-title child) "(untitled)")
-                                             (ekg-note-id child)))
-                                   children "\n"))))
-         (prompt-notes (ekg-get-notes-cotagged-with-tags
-                        (ekg-note-tags note) ekg-llm-prompt-tag))
-         (prompt-context (when prompt-notes
-                           (concat "\n\nPrompt instructions from co-tagged notes:\n"
-                                   (mapconcat (lambda (n)
-                                                (string-trim
-                                                 (substring-no-properties
-                                                  (ekg-display-note-text n nil 'plaintext))))
-                                              prompt-notes "\n"))))
-         (context (concat
-                   "You are executing an org task autonomously. Here is the full task hierarchy, "
-                   "from the root task down to the current task you must execute:\n\n"
-                   hierarchy-text
-                   (or children-text "")
-                   (or prompt-context "")
-                   "\n\n"
-                   (format "The current date and time is %s." (format-time-string "%F %R"))))
-         (question (concat
-                    (format "Execute the following task: '%s' (note id: %s).\n\n" title task-id)
-                    "Complete this task using the tools available to you. "
-                    "You should NOT ask the user for input. Work autonomously.\n\n"
-                    "When you are done, you MUST call the `set_org_item_status` tool to "
-                    "set this task's status (typically to DONE, or WAITING if blocked). "
-                    "Calling `set_org_item_status` will end your session.\n\n"
-                    "Before setting the status, use `display_result_in_popup` to tell the user what you did.")))
-    (ekg-agent--iterate (llm-make-chat-prompt
-                         question
-                         :context (concat (ekg-agent-instructions-intro) "\n\n" context)
-                         :tools (ekg-agent--tools
-                                 (list ekg-agent-tool-popup-result
-                                       ekg-org-tool-add-task
-                                       ekg-org-tool-set-status
-                                       ekg-org-tool-list-items))
-                         :tool-options (make-llm-tool-options :tool-choice 'any))
-                        0
-                        (ekg-agent--make-status-callback)
-                        '("set_org_item_status")
-                        (ekg-agent--timeout-deadline))))
-
 (defun ekg-org-fs-handler (operation &rest args)
   "Fake our ekg data as a file.
 
@@ -389,53 +315,6 @@ Optionally check NOTE to only revert when org tasks change."
 ;; But without this, we get an error.
 (add-to-list 'auto-mode-alist '("\\.org_archive" . org-mode))
 
-(defun ekg-org--agent-tool-add-item (title content tags parent-id status deadline scheduled)
-  "Add a new org task item to EKG.
-
-TITLE is the task title.
-CONTENT is the task content/description.
-TAGS is a list of additional tags.
-PARENT-ID is the parent task ID (nil for no parent)
-STATUS is the task status (will be converted to uppercase).
-DEADLINE is the deadline timestamp string (ignored if empty).
-SCHEDULED is the scheduled timestamp string (ignored if empty)."
-  (ekg-agent--with-error-as-text
-    (let* ((note (ekg-note-create :text content
-                                  :tags (append (list ekg-org-task-tag) tags
-                                                (when (and status (not (string-empty-p status)))
-                                                  (list (concat ekg-org-state-tag-prefix (downcase status)))))
-                                  :properties (list :titled/title (list title)))))
-      ;; Handle parent ID
-      (when (and parent-id (not (equal parent-id 0)) (not (string-empty-p (format "%s" parent-id))))
-        (setf (ekg-note-properties note) (plist-put (ekg-note-properties note) :org/parent parent-id)))
-      ;; Handle deadline
-      (when (and deadline (not (string-empty-p deadline)))
-        (setf (ekg-note-properties note) (plist-put (ekg-note-properties note) :org/deadline (ekg-org--to-timestamp deadline))))
-      ;; Handle scheduled
-      (when (and scheduled (not (string-empty-p scheduled)))
-        (setf (ekg-note-properties note) (plist-put (ekg-note-properties note) :org/scheduled (ekg-org--to-timestamp scheduled))))
-      ;; Save the note
-      (ekg-save-note note)
-      (format "Added note with ID %s" (ekg-note-id note)))))
-
-(defun ekg-org--agent-tool-set-status (id status)
-  "Set the status of an org task item.
-
-ID is the note ID.
-STATUS is the new status (will be converted to uppercase)."
-  (ekg-agent--with-error-as-text
-    (let ((note (ekg-get-note-with-id id)))
-      (unless note
-        (error "No note found with ID %s" id))
-      (setf (ekg-note-tags note)
-            (cons
-             (concat ekg-org-state-tag-prefix (downcase status))
-             (seq-remove
-              (lambda (tag) (string-prefix-p ekg-org-state-tag-prefix tag))
-              (ekg-note-tags note))))
-      (ekg-save-note note)
-      (format "Set status of note ID %s to %s" id status))))
-
 (defun ekg-org--state (note)
   "Get the org state of NOTE."
   (let ((tags (ekg-note-tags note)))
@@ -446,64 +325,16 @@ STATUS is the new status (will be converted to uppercase)."
           (upcase (string-replace ekg-org-state-tag-prefix "" tag))
         (error "No org state tag found for note ID %s" (ekg-note-id note))))))
 
-(defun ekg-org--agent-tool-list-items (&optional state)
-  "List all org task items.
-
-STATE if non-nil, filter by status (e.g., \"TODO\", \"DONE\").
-Returns text in Org format, as if they were in an Org file."
-  (ekg-agent--with-error-as-text
-    (let ((result (ekg-org-generate-org-content
-                   nil (when state
-                         (lambda (note)
-                           (string-equal
-                            (downcase state)
-                            (downcase (ekg-org--state note))))))))
-      (if (string-empty-p result)
-          (if state
-              (format "No org items found with state %s." state)
-            "No org items found.")
-        result))))
-
-(defconst ekg-org-tool-add-task
-  (llm-make-tool
-   :function #'ekg-org--agent-tool-add-item
-   :name "add_org_item"
-   :description "Add a new org-mode task item"
-   :args
-   '((:name "title" :type string :description "The title/headline of the task" :require t)
-     (:name "content" :type string :description "The content/description of the task" :required t)
-     (:name "tags" :type array :items (:type string)
-            :description "Additional tags for the task (org tags and agent tags will be added automatically)")
-     (:name "parent_id" :type integer :description "The parent task ID if exists")
-     (:name "status" :type string :description "The task status (TODO, DONE, etc.), will default to TODO if not set")
-     (:name "deadline" :type string :description "The deadline timestamp in ISO 8601 format")
-     (:name "scheduled" :type string :description "The scheduled timestamp in ISO 8601 format"))))
-
-(defconst ekg-org-tool-set-status
-  (llm-make-tool
-   :function #'ekg-org--agent-tool-set-status
-   :name "set_org_item_status"
-   :description "Set the status of an org-mode task item.  Use this when you want to change the status of an existing task, for example setting it to DONE when completing it, or marking it WAITING if it's on hold."
-   :args
-   '((:name "id" :type integer :description "The ID of the task item" :required t)
-     (:name "status" :type string :description "The new status of the task (TODO, DONE, etc.)" :required t))))
-
-(defconst ekg-org-tool-list-items
-  (llm-make-tool
-   :function #'ekg-org--agent-tool-list-items
-   :name "list_org_items"
-   :description "Return all matching org-mode task items as an Org formatted string."
-   :args
-   '((:name "state" :type string
-            :description "Filter tasks by state (TODO, DONE, etc.)"))))
-
 (defun ekg-org-initialize ()
-  "Initialize the ekg-org integration."
+  "Initialize the ekg-org integration.
+
+This adds the necessary schema and, if `ekg-agent' is available,
+registers tools for interacting with org tasks."
   (ekg-org-add-schema)
   (when (featurep 'ekg-agent)
-    (add-to-list 'ekg-agent-extra-tools ekg-org-tool-add-task)
-    (add-to-list 'ekg-agent-extra-tools ekg-org-tool-set-status)
-    (add-to-list 'ekg-agent-extra-tools ekg-org-tool-list-items)))
+    (add-to-list 'ekg-agent-extra-tools ekg-agent-org-tool-add-task)
+    (add-to-list 'ekg-agent-extra-tools ekg-agent-org-tool-set-status)
+    (add-to-list 'ekg-agent-extra-tools ekg-agent-org-tool-list-items)))
 
 (provide 'ekg-org)
 ;;; ekg-org.el ends here

--- a/ekg-org.el
+++ b/ekg-org.el
@@ -30,10 +30,11 @@
 (require 'ekg)
 (require 'llm)
 
-;; Forward declarations for variables defined later in this file.
-(defvar ekg-org-tool-add-task)
-(defvar ekg-org-tool-set-status)
-(defvar ekg-org-tool-list-items)
+;; Forward declarations for variables defined in ekg-agent.el.
+(defvar ekg-agent-extra-tools)
+(defvar ekg-agent-org-tool-add-task)
+(defvar ekg-agent-org-tool-set-status)
+(defvar ekg-agent-org-tool-list-items)
 
 (defconst ekg-org-state-tag-prefix "org/state/"
   "Prefix for EKG tags representing Org TODO states.")

--- a/ekg-pkg.el
+++ b/ekg-pkg.el
@@ -3,7 +3,7 @@
 ;;; Commentary: This defines the package for ekg.
 ;;; Code:
 
-(define-package "ekg" "20260305"
+(define-package "ekg" "0.8.0"
   "A sqlite-based note-taking package based on tags."
   '((triples "0.6.1")
     (emacs   "28.1")

--- a/ekg-pkg.el
+++ b/ekg-pkg.el
@@ -1,0 +1,13 @@
+;;; ekg-pkg.el --- Package definition for ekg -*- no-byte-compile: t -*-
+
+;;; Commentary: This defines the package for ekg.
+;;; Code:
+
+(define-package "ekg" "20260305"
+  "A sqlite-based note-taking package based on tags."
+  '((triples "0.6.1")
+    (emacs   "28.1")
+    (llm "0.18.0")))
+
+(provide 'ekg-pkg)
+;;; ekg-pkg.el ends here

--- a/ekg.el
+++ b/ekg.el
@@ -1,6 +1,6 @@
 ;;; ekg.el --- A system for recording and linking information -*- lexical-binding: t -*-
 
-;; Copyright (c) 2022-2025  Andrew Hyatt <ahyatt@gmail.com>
+;; Copyright (c) 2022-2026  Andrew Hyatt <ahyatt@gmail.com>
 
 ;; Author: Andrew Hyatt <ahyatt@gmail.com>
 ;; Homepage: https://github.com/ahyatt/ekg


### PR DESCRIPTION
Two new packages: `ekg-denote` (requires denote), and `ekg-agent` (requires async).

This is part of a fix for https://github.com/ahyatt/ekg/issues/263. The other part is the MELPA change to add the repositories.