### PR TITLE
Return nil from ekg-get-note-with-id for nonexistent IDs

### DIFF
--- a/contrib/ekg-email.el
+++ b/contrib/ekg-email.el
@@ -123,10 +123,10 @@ an email address that is part of what we store in the triples."
   (ekg-setup-notes-buffer
    (format "with address: %s" addr)
    (lambda () (sort
-               (mapcar #'ekg-get-note-with-id
-                       (seq-filter
-                        #'ekg-active-id-p
-                        (ekg-email-get-notes-ids-with-address addr)))
+               (delq nil (mapcar #'ekg-get-note-with-id
+                                 (seq-filter
+                                  #'ekg-active-id-p
+                                  (ekg-email-get-notes-ids-with-address addr))))
                #'ekg-sort-by-creation-time))
    nil))
 

--- a/ekg-agent.el
+++ b/ekg-agent.el
@@ -246,31 +246,16 @@ tool call."
                  :description "List all existing tags in the ekg database."
                  :args '((:name "regex_filter" :type string :description "Optional regex to filter the tags by"))))
 
-(defun ekg-agent--note-exists-p (note)
-  "Return non-nil if NOTE represents an actual stored note.
-`ekg-get-note-with-id' always returns a struct even for
-nonexistent IDs, so we check for a creation-time to distinguish
-real notes from empty shells."
-  (and note (ekg-note-creation-time note)))
-
 (defun ekg-agent--get-note-with-id (id)
   "Retrieve the note with string ID, handling different ID types.
 
 This tries a few different things, since ekg ids can be of various
-types, but we'll only get strings from the LLM.
-`ekg-get-note-with-id' always returns a struct even when the ID
-doesn't exist, so we verify the note has data before accepting it."
-  (let ((note (ekg-get-note-with-id id)))
-    (if (ekg-agent--note-exists-p note)
-        note
+types, but we'll only get strings from the LLM."
+  (or (ekg-get-note-with-id id)
       (let ((int-id (string-to-number id)))
         (when (> int-id 0)
-          (setq note (ekg-get-note-with-id int-id))))
-      (if (ekg-agent--note-exists-p note)
-          note
-        (setq note (ekg-get-note-with-id (intern id)))
-        (when (ekg-agent--note-exists-p note)
-          note)))))
+          (ekg-get-note-with-id int-id)))
+      (ekg-get-note-with-id (intern id))))
 
 (defconst ekg-agent-tool-append-to-note
   (make-llm-tool :function (lambda (id content)
@@ -1997,15 +1982,15 @@ Returns a list of note objects."
       (unless ekg-embedding-provider
         (error "Semantic search requires ekg-embedding-provider to be configured"))
       (let ((embedding (llm-embedding ekg-embedding-provider semantic-search)))
-        (mapcar #'ekg-get-note-with-id
-                (ekg-embedding-n-most-similar-notes embedding num))))
+        (delq nil (mapcar #'ekg-get-note-with-id
+                         (ekg-embedding-n-most-similar-notes embedding num)))))
 
      ;; Text search (full-text search)
      (text-search
       (seq-take
        (seq-filter #'ekg-note-active-p
-                   (mapcar #'ekg-get-note-with-id
-                           (triples-fts-query-subject ekg-db text-search ekg-query-pred-abbrevs)))
+                   (delq nil (mapcar #'ekg-get-note-with-id
+                                     (triples-fts-query-subject ekg-db text-search ekg-query-pred-abbrevs))))
        num))
 
      ;; Tag-based search with OR logic (already sorted by creation time)

--- a/ekg-embedding.el
+++ b/ekg-embedding.el
@@ -289,7 +289,7 @@ printed when everything is finished."
                                                  (ekg-embedding-get id)))))
                       (ekg-active-note-ids)))
          (notes-to-generate
-          (seq-filter (lambda (note) (> (length (ekg-note-text note)) 0))
+          (seq-filter (lambda (note) (and note (> (length (ekg-note-text note)) 0)))
                       (mapcar #'ekg-get-note-with-id to-generate))))
     (cl-labels ((complete-id (num)
                   (cl-incf count num)
@@ -317,7 +317,8 @@ printed when everything is finished."
 
         ;; Process empty notes
         (cl-loop for id in to-generate
-                 when (= (length (ekg-note-text (ekg-get-note-with-id id))) 0)
+                 for note = (ekg-get-note-with-id id)
+                 when (or (null note) (= (length (ekg-note-text note)) 0))
                  collect id into ids
                  finally
                  do (complete-id (length ids)))
@@ -451,10 +452,11 @@ The results are in order of most similar to least similar."
   (let ((note (ekg-current-note-or-error)))
     (ekg-setup-notes-buffer
      (format "similar to note \"%s\"" (ekg-note-snippet note))
-     (lambda () (mapcar #'ekg-get-note-with-id
-                        ;; remove the first match, since the current note will
-                        ;; always be the most similar.
-                        (cdr (ekg-embedding-n-most-similar-to-id (ekg-note-id note) ekg-notes-size))))
+     (lambda () (delq nil
+                      (mapcar #'ekg-get-note-with-id
+                              ;; remove the first match, since the current note will
+                              ;; always be the most similar.
+                              (cdr (ekg-embedding-n-most-similar-to-id (ekg-note-id note) ekg-notes-size)))))
      (ekg-note-tags note))))
 
 (defun ekg-embedding-search (&optional text)
@@ -463,9 +465,10 @@ The results are in order of most similar to least similar."
   (ekg-embedding-connect)
   (ekg-setup-notes-buffer
    (format "similar to \"%s\"" text)
-   (lambda () (mapcar #'ekg-get-note-with-id (ekg-embedding-n-most-similar-notes
-                                              (llm-embedding ekg-embedding-provider text)
-                                              ekg-notes-size)))
+   (lambda () (delq nil
+                    (mapcar #'ekg-get-note-with-id (ekg-embedding-n-most-similar-notes
+                                                    (llm-embedding ekg-embedding-provider text)
+                                                    ekg-notes-size))))
    nil))
 
 (defun ekg-embedding-show-similar-to-current-buffer ()
@@ -474,12 +477,13 @@ The results are in order of most similar to least similar."
   (ekg-embedding-connect)
   (ekg-setup-notes-buffer
    (format "similar to buffer \"%s\"" (buffer-name (current-buffer)))
-   (lambda () (mapcar #'ekg-get-note-with-id
-                      (ekg-embedding-n-most-similar-notes
-                       (llm-embedding ekg-embedding-provider
-                                      (funcall ekg-embedding-text-selector
-                                               (substring-no-properties (buffer-string))))
-                       ekg-notes-size)))
+   (lambda () (delq nil
+                    (mapcar #'ekg-get-note-with-id
+                            (ekg-embedding-n-most-similar-notes
+                             (llm-embedding ekg-embedding-provider
+                                            (funcall ekg-embedding-text-selector
+                                                     (substring-no-properties (buffer-string))))
+                             ekg-notes-size))))
    nil))
 
 (defun ekg-embedding-generate-on-save ()

--- a/ekg-llm.el
+++ b/ekg-llm.el
@@ -288,7 +288,8 @@ structs."
                           1000)))
       (dolist (id similar-notes)
         (let ((note (ekg-get-note-with-id id)))
-          (when (and (ekg-note-is-content-p note)
+          (when (and note
+                     (ekg-note-is-content-p note)
                      (not (member ekg-llm-prompt-tag (ekg-note-tags note))))
             (iter-yield (ekg-llm-note-to-text note))))))))
 

--- a/ekg-logseq.el
+++ b/ekg-logseq.el
@@ -444,7 +444,9 @@ which will import and re-export back to logseq."
                 (seq-uniq
                  (cl-loop for triples in
                           (triples-db-select-pred-op ekg-db :time-tracked/modified-time '> time)
-                          nconc (ekg-note-tags (ekg-get-note-with-id (car triples))))))))
+                          for note = (ekg-get-note-with-id (car triples))
+                          when note
+                          nconc (ekg-note-tags note))))))
 
 (defun ekg-logseq-export ()
   "Export the current ekg database to logseq.

--- a/ekg-org.el
+++ b/ekg-org.el
@@ -826,8 +826,9 @@ trashed, they are permanently deleted."
   "Create a new sibling task after the task at point."
   (interactive)
   (let* ((id (ekg-org-view--note-at-point))
-         (parent-id (when id
-                      (plist-get (ekg-note-properties (ekg-get-note-with-id id))
+         (note (when id (ekg-get-note-with-id id)))
+         (parent-id (when note
+                      (plist-get (ekg-note-properties note)
                                  :org/parent)))
          (siblings (if parent-id
                        (ekg-org-view--sorted-children parent-id)
@@ -930,10 +931,9 @@ skipped."
             (unless (member id seen-ids)
               (push id seen-ids)
               (push (list (point) id level
-                          (when id
-                            (plist-get (ekg-note-properties
-                                       (ekg-get-note-with-id id))
-                                      :org/parent)))
+                          (when-let* ((note (and id (ekg-get-note-with-id id))))
+                            (plist-get (ekg-note-properties note)
+                                       :org/parent)))
                     headings))))
         (forward-line 1)))
     (nreverse headings)))

--- a/ekg-org.el
+++ b/ekg-org.el
@@ -156,13 +156,13 @@ active, unarchived, tasks."
                  (if archive
                      (member ekg-org-archive-tag tags)
                    (not (member ekg-org-archive-tag tags))))))))
-     (mapcar #'ekg-get-note-with-id top-ids))))
+     (delq nil (mapcar #'ekg-get-note-with-id top-ids)))))
 
 (defun ekg-org-get-child-notes-of-id (id)
   "Fetch child notes of a given note ID."
   (seq-filter #'ekg-note-active-p
-              (mapcar (lambda (row) (ekg-get-note-with-id (car row)))
-                      (triples-db-select ekg-db nil 'org/parent id))))
+              (delq nil (mapcar (lambda (row) (ekg-get-note-with-id (car row)))
+                                (triples-db-select ekg-db nil 'org/parent id)))))
 
 (defun ekg-org--format-timestamp (timestamp)
   "Parse TIMESTAMP integer into an Org timestamp string."

--- a/ekg.el
+++ b/ekg.el
@@ -608,52 +608,53 @@ Draft notes are not returned, unless TAGS contains the draft tag."
 (defun ekg-get-note-with-id (id)
   "Get the note with ID, or nil if it does not exist."
   (ekg-connect)
-  (let* ((v (triples-get-subject ekg-db id))
-         (stored-types (triples-get-types ekg-db id))
-         (core-types '(text time-tracked inline titled tagged))
-         (inlines (mapcar (lambda (iid)
-                            (let ((iv (triples-get-type ekg-db iid
-                                                        'inline)))
-                              (make-ekg-inline :pos (plist-get iv :pos)
-                                               :command (cons
-                                                         (plist-get iv :command)
-                                                         (plist-get iv :args))
-                                               :type (plist-get iv :type))))
-                          (plist-get v :text/inlines)))
-         ;; Query extension types not already returned by triples-get-subject,
-         ;; to pick up virtual reversed properties like org/children.
-         (extra-props
-          (mapcan (lambda (type)
-                    (unless (or (memq type stored-types)
-                                (memq type core-types))
-                      (let ((type-data (triples-get-type ekg-db id type)))
-                        (when type-data
-                          (cl-loop for (k v) on type-data by #'cddr
-                                   nconc (list (intern (format ":%s/%s" type
-                                                               (substring (symbol-name k) 1)))
-                                               v))))))
-                  (ekg-note-cotypes))))
+  (let ((v (triples-get-subject ekg-db id)))
     (when v
-      (make-ekg-note :id id
-                     :text (plist-get v :text/text)
-                     :mode (plist-get v :text/mode)
-                     :inlines inlines
-                     :tags (plist-get v :tagged/tag)
-                     :creation-time (plist-get v :time-tracked/creation-time)
-                     :modified-time (plist-get v :time-tracked/modified-time)
-                     :properties (append
-                                  (map-into
-                                   (map-filter
-                                    (lambda (plist-key _)
-                                      (not (member plist-key
-                                                   '(:text/text
-                                                     :text/mode
-                                                     :text/inlines
-                                                     :tagged/tag
-                                                     :time-tracked/creation-time
-                                                     :time-tracked/modified-time)))) v)
-                                   'plist)
-                                  extra-props)))))
+      (let* ((stored-types (triples-get-types ekg-db id))
+             (core-types '(text time-tracked inline titled tagged))
+             (inlines (mapcar (lambda (iid)
+                                (let ((iv (triples-get-type ekg-db iid
+                                                            'inline)))
+                                  (make-ekg-inline :pos (plist-get iv :pos)
+                                                   :command (cons
+                                                             (plist-get iv :command)
+                                                             (plist-get iv :args))
+                                                   :type (plist-get iv :type))))
+                              (plist-get v :text/inlines)))
+             ;; Query extension types not already returned by
+             ;; triples-get-subject, to pick up virtual reversed
+             ;; properties like org/children.
+             (extra-props
+              (mapcan (lambda (type)
+                        (unless (or (memq type stored-types)
+                                    (memq type core-types))
+                          (let ((type-data (triples-get-type ekg-db id type)))
+                            (when type-data
+                              (cl-loop for (k v) on type-data by #'cddr
+                                       nconc (list (intern (format ":%s/%s" type
+                                                                   (substring (symbol-name k) 1)))
+                                                   v))))))
+                      (ekg-note-cotypes))))
+        (make-ekg-note :id id
+                       :text (plist-get v :text/text)
+                       :mode (plist-get v :text/mode)
+                       :inlines inlines
+                       :tags (plist-get v :tagged/tag)
+                       :creation-time (plist-get v :time-tracked/creation-time)
+                       :modified-time (plist-get v :time-tracked/modified-time)
+                       :properties (append
+                                    (map-into
+                                     (map-filter
+                                      (lambda (plist-key _)
+                                        (not (member plist-key
+                                                     '(:text/text
+                                                       :text/mode
+                                                       :text/inlines
+                                                       :tagged/tag
+                                                       :time-tracked/creation-time
+                                                       :time-tracked/modified-time)))) v)
+                                     'plist)
+                                    extra-props))))))
 
 (defun ekg-get-notes-with-title (title)
   "Get a list of note structs with TITLE."
@@ -2555,7 +2556,9 @@ as long as those notes aren't on resources that are interesting.
                (if (or (null note) (null (ekg-note-creation-time note)))
                    (progn
                      (message "ekg-clean-db: Deleting note %s, reason: no text or creation date" id)
-                     (ekg-note-delete note)
+                     (if note
+                         (ekg-note-delete note)
+                       (triples-delete-subject ekg-db id))
                      (setq deleted t))
                  (message "ekg-clean-db: Fixed nil text for note %s" id)
                  (setf (ekg-note-text note) "")

--- a/ekg.el
+++ b/ekg.el
@@ -579,10 +579,11 @@ Draft notes are not returned, unless TAGS contains the draft tag."
                     (and (not (member hidden-tag tags))
                          (member hidden-tag (ekg-note-tags note))))
                   ekg-hidden-tags)))
-     (mapcar #'ekg-get-note-with-id
-             (seq-reduce #'seq-intersection
-                         ids-by-tag
-                         (car ids-by-tag))))))
+     (delq nil
+           (mapcar #'ekg-get-note-with-id
+                   (seq-reduce #'seq-intersection
+                               ids-by-tag
+                               (car ids-by-tag)))))))
 
 (defun ekg-get-notes-with-tag (tag)
   "Get all notes with TAG, returning a list of `ekg-note' structs."
@@ -605,8 +606,7 @@ Draft notes are not returned, unless TAGS contains the draft tag."
   (triples-get-subject ekg-db id))
 
 (defun ekg-get-note-with-id (id)
-  "Get the specific note with ID.
-If the ID does not exist, create a new note with that ID."
+  "Get the note with ID, or nil if it does not exist."
   (ekg-connect)
   (let* ((v (triples-get-subject ekg-db id))
          (stored-types (triples-get-types ekg-db id))
@@ -633,31 +633,32 @@ If the ID does not exist, create a new note with that ID."
                                                                (substring (symbol-name k) 1)))
                                                v))))))
                   (ekg-note-cotypes))))
-    (make-ekg-note :id id
-                   :text (plist-get v :text/text)
-                   :mode (plist-get v :text/mode)
-                   :inlines inlines
-                   :tags (plist-get v :tagged/tag)
-                   :creation-time (plist-get v :time-tracked/creation-time)
-                   :modified-time (plist-get v :time-tracked/modified-time)
-                   :properties (append
-                                (map-into
-                                 (map-filter
-                                  (lambda (plist-key _)
-                                    (not (member plist-key
-                                                 '(:text/text
-                                                   :text/mode
-                                                   :text/inlines
-                                                   :tagged/tag
-                                                   :time-tracked/creation-time
-                                                   :time-tracked/modified-time)))) v)
-                                 'plist)
-                                extra-props))))
+    (when v
+      (make-ekg-note :id id
+                     :text (plist-get v :text/text)
+                     :mode (plist-get v :text/mode)
+                     :inlines inlines
+                     :tags (plist-get v :tagged/tag)
+                     :creation-time (plist-get v :time-tracked/creation-time)
+                     :modified-time (plist-get v :time-tracked/modified-time)
+                     :properties (append
+                                  (map-into
+                                   (map-filter
+                                    (lambda (plist-key _)
+                                      (not (member plist-key
+                                                   '(:text/text
+                                                     :text/mode
+                                                     :text/inlines
+                                                     :tagged/tag
+                                                     :time-tracked/creation-time
+                                                     :time-tracked/modified-time)))) v)
+                                   'plist)
+                                  extra-props)))))
 
 (defun ekg-get-notes-with-title (title)
   "Get a list of note structs with TITLE."
   (ekg-connect)
-  (mapcar #'ekg-get-note-with-id (triples-subjects-with-predicate-object ekg-db 'titled/title title)))
+  (delq nil (mapcar #'ekg-get-note-with-id (triples-subjects-with-predicate-object ekg-db 'titled/title title))))
 
 (defun ekg-note-delete (note)
   "Delete NOTE from the database."
@@ -717,10 +718,11 @@ Those tags are things such as `ekg-draft-tag', or `ekg-function-tag'."
 
 (defun ekg-active-id-p (id)
   "Return non-nil if the note with ID is active.
-This will return true if the note is not a draft, and has at
-least one non-trash tag."
+This will return true if the note exists, is not a draft, and has
+at least one non-trash tag."
   (ekg-connect)
-  (ekg-note-active-p (ekg-get-note-with-id id)))
+  (let ((note (ekg-get-note-with-id id)))
+    (and note (ekg-note-active-p note))))
 
 (defun ekg-live-id-p (sub)
   "Return non-nil if SUB represents an undeleted note."
@@ -958,7 +960,9 @@ NUMWORDS and FORMAT are as described in `ekg-display-note-template'."
 (defun ekg-inline-command-transclude-note (id &optional numwords)
   "Return the text of ID.
 NUMWORDS is the maximum number of words to use."
-  (string-trim-right (ekg-display-note-text (ekg-get-note-with-id id) numwords) "\n"))
+  (if-let* ((note (ekg-get-note-with-id id)))
+      (string-trim-right (ekg-display-note-text note numwords) "\n")
+    (format "[Note %s not found]" id)))
 
 (defun ekg-inline-command-transclude-file (file &optional numwords)
   "Return the contents of FILE.
@@ -1852,7 +1856,8 @@ Raise an error if there is no current note."
   (unless (eq major-mode 'ekg-notes-mode)
     (error "This command can only be used in `ekg-notes-mode'"))
   (if-let* ((id (get-text-property (point) :ekg-note-id)))
-      (ekg-get-note-with-id id)
+      (or (ekg-get-note-with-id id)
+          (error "Note with ID %s no longer exists" id))
     (error "No current note is available to act on!  Create a new note first with `ekg-capture'")))
 
 (declare-function ekg-org-view--note-at-point "ekg-org")
@@ -1868,7 +1873,8 @@ intended to be used in any context where a note might be available."
            ekg-note)
       (and (derived-mode-p 'ekg-org-view-mode)
            (let ((id (ekg-org-view--note-at-point)))
-             (if id (ekg-get-note-with-id id)
+             (if id (or (ekg-get-note-with-id id)
+                        (error "Note with ID %s no longer exists" id))
                (error "No task at point"))))
       (error "No current note found in context")))
 
@@ -2150,7 +2156,7 @@ Text included in inline templates is not searched."
   (ekg-connect)
   (ekg-setup-notes-buffer
    (format "query: %s" query)
-   (lambda () (seq-filter #'ekg-note-active-p (mapcar #'ekg-get-note-with-id (triples-fts-query-subject ekg-db query ekg-query-pred-abbrevs)))) nil))
+   (lambda () (seq-filter #'ekg-note-active-p (delq nil (mapcar #'ekg-get-note-with-id (triples-fts-query-subject ekg-db query ekg-query-pred-abbrevs))))) nil))
 
 ;;;###autoload
 (defun ekg-show-notes-in-trash ()
@@ -2318,11 +2324,12 @@ Returns a list of matching notes, up to LIMIT if provided."
   (let ((plainquery (substring-no-properties query))
         (limit (or limit ekg-search-max-results)))
     (ekg-connect)
-    (mapcar #'ekg-get-note-with-id
-            (seq-difference
-             (mapcar #'car (seq-union (triples-search ekg-db :text/text plainquery limit)
-                                      (triples-search ekg-db :titled/title plainquery limit)))
-             (ekg-inactive-note-ids)))))
+    (delq nil
+          (mapcar #'ekg-get-note-with-id
+                  (seq-difference
+                   (mapcar #'car (seq-union (triples-search ekg-db :text/text plainquery limit)
+                                            (triples-search ekg-db :titled/title plainquery limit)))
+                   (ekg-inactive-note-ids))))))
 
 (defun ekg-show-notes-with-search-results (query)
   "Show notes that match the search QUERY."
@@ -2542,10 +2549,10 @@ as long as those notes aren't on resources that are interesting.
   (cl-loop for id in (triples-subjects-of-type ekg-db 'text) do
            (let ((note (ekg-get-note-with-id id))
                  (deleted))
-             (unless (ekg-note-text note)
+             (unless (and note (ekg-note-text note))
                ;; As a heuristic, if this note is sufficiently weird that
                ;; there's no creation date, delete it, otherwise try to fix it.
-               (if (null (ekg-note-creation-time note))
+               (if (or (null note) (null (ekg-note-creation-time note)))
                    (progn
                      (message "ekg-clean-db: Deleting note %s, reason: no text or creation date" id)
                      (ekg-note-delete note)
@@ -2628,7 +2635,10 @@ STAGS is a string version of a tag, as stored in a link."
 
 (defun ekg--open-note-link (id)
   "Open a link to a note given its ID."
-  (ekg-edit (ekg-get-note-with-id (read id))))
+  (let ((note (ekg-get-note-with-id (read id))))
+    (if note
+        (ekg-edit note)
+      (error "Note with ID %s not found" id))))
 
 (org-link-set-parameters "ekg-tag" :follow #'ekg--open-tag-link
                          :store #'ekg--store-tag-link)


### PR DESCRIPTION
Previously, ekg-get-note-with-id always returned a make-ekg-note struct even when the ID didn't exist in the database, with nil for all fields.  This was a source of subtle bugs: callers that used the result without checking would crash or produce incorrect behavior (e.g., writing nil creation-time to the DB).

Now the function returns nil when triples-get-subject returns no data.  All callers across the codebase are updated:
- mapcar calls wrapped with delq nil
- Direct callers given nil guards where needed
- ekg-agent--get-note-with-id simplified back to a simple or-chain
- ekg-active-id-p handles nil note
- ekg-clean-db handles nil note in its cleanup logic
- ekg-current-note-or-error signals clear error for missing notes
- Transclusion returns placeholder text for missing notes