### PR TITLE
Fix non-vecdb embedding generation, warn instead of error

### DIFF
--- a/ekg-embedding.el
+++ b/ekg-embedding.el
@@ -171,9 +171,12 @@ wait for the embedding to return and be set."
                              (substring-no-properties
                               (ekg-display-note-text note ekg-embedding-max-words 'plaintext))))))
     (if (ekg-embedding-valid-p embedding)
-        (triples-set-type ekg-db (ekg-note-id note) 'embedding
-                          :embedding embedding)
-      (lwarn 'ekg :error "Invalid and unusable embedding generated from llm-embedding of note %s: %S"
+        (if ekg-vecdb-provider
+            (ekg-embedding-batch-store
+             (list (ekg-embedding--note-to-embed-item note embedding)))
+          (triples-set-type ekg-db (ekg-note-id note) 'embedding
+                            :embedding embedding))
+      (lwarn '(ekg embedding-generation) :error "Invalid and unusable embedding generated from llm-embedding of note %s: %S"
              (ekg-note-id note) embedding))))
 
 (defun ekg-embedding-batch-store (items)
@@ -248,17 +251,23 @@ embeddings of notes with the given tag."
       (let ((embeddings
              (cl-loop for tagged in
                       (plist-get (triples-get-type ekg-db tag 'tag) :tagged)
+                      for note = (ekg-get-note-with-id tagged)
+                      ;; Skip deleted notes that are still in the tag list.
+                      when note
                       collect
                       (let ((embedding (ekg-embedding-get tagged)))
                         (unless (ekg-embedding-valid-p embedding)
                           (message "ekg-embedding: invalid embedding for note %s, attempting to fix" tagged)
-                          (let ((note (ekg-get-note-with-id tagged)))
-                            (ekg-embedding-generate-for-note-sync note)
-                            (if (ekg-embedding-valid-p (ekg-embedding-note-get note))
-                                (progn
-                                  (ekg-save-note note)
-                                  (setf embedding (ekg-embedding-note-get note)))
-                              (error "In ekg-embedding: could not fix invalid embedding for note %s, can't refresh tag %s" tagged tag))))
+                          (condition-case nil
+                              (progn
+                                (ekg-embedding-generate-for-note-sync note)
+                                (let ((new-embedding (ekg-embedding-note-get note)))
+                                  (when (ekg-embedding-valid-p new-embedding)
+                                    (ekg-save-note note)
+                                    (setf embedding new-embedding))))
+                            (error nil))
+                          (unless (ekg-embedding-valid-p embedding)
+                            (warn "ekg-embedding: could not fix invalid embedding for note %s, skipping" tagged)))
                         embedding))))
         (let ((avg (ekg-embedding-average
                     (seq-filter #'ekg-embedding-valid-p embeddings))))

--- a/ekg-test.el
+++ b/ekg-test.el
@@ -461,6 +461,30 @@
         ;; The primary check is that fewer words are returned than originally present.
         (should (= (ekg-test-count-words-in-string selected-text) 5460))))))
 
+(ekg-deftest ekg-test-embedding-refresh-skips-unfixable ()
+  "Refreshing a tag embedding skips notes whose embeddings can't be fixed."
+  (let* ((good-embedding [0.1 0.2 0.3])
+         (bad-embedding [0 0 0])
+         (ekg-embedding-provider 'fake)
+         (ekg-vecdb-provider nil))
+    ;; Create two notes under the same tag.
+    (let ((good-note (ekg-note-create :text "good note" :mode 'text-mode :tags '("test-tag")))
+          (bad-note (ekg-note-create :text "" :mode 'text-mode :tags '("test-tag"))))
+      (ekg-save-note good-note)
+      (ekg-save-note bad-note)
+      ;; Store a valid embedding for the good note and an invalid one for the bad note.
+      (ekg-embedding-add-schema)
+      (triples-set-type ekg-db (ekg-note-id good-note) 'embedding :embedding good-embedding)
+      (triples-set-type ekg-db (ekg-note-id bad-note) 'embedding :embedding bad-embedding)
+      ;; Mock llm-embedding to always return an invalid embedding, so the
+      ;; fix attempt for the bad note will fail.
+      (cl-letf (((symbol-function 'llm-embedding)
+                 (lambda (_provider _text) bad-embedding)))
+        ;; This should NOT error -- it should skip the unfixable note.
+        (ekg-embedding-refresh-tag-embedding "test-tag")
+        ;; The good note's embedding should still be retrievable.
+        (should (ekg-embedding-valid-p (ekg-embedding-get (ekg-note-id good-note))))))))
+
 (ekg-deftest ekg-test-always-have-header-line ()
              (ekg-capture)
              (should header-line-format)


### PR DESCRIPTION
Instead of erroring, just warn about unusuable embeddings