### PR TITLE
run ekg tests in a clean environment

### DIFF
--- a/ekg-agent-llm-test.el
+++ b/ekg-agent-llm-test.el
@@ -34,7 +34,7 @@
 (unless (require 'llm-test nil t)
   ;; When llm-test is unavailable, define a single skipped test so eldev does
   ;; not error on loading this file.
-  (ert-deftest ekg-agent-llm-test/unavailable ()
+  (ekg-deftest ekg-agent-llm-test/unavailable ()
     "Placeholder — llm-test library not found."
     (ert-skip "llm-test library not available")))
 

--- a/ekg-agent-test.el
+++ b/ekg-agent-test.el
@@ -25,59 +25,60 @@
 
 (require 'ert)
 (require 'ekg-agent)
+(require 'ekg-test-utils)
 
 ;; Indentation adjustment
 
-(ert-deftest ekg-agent-test-adjust-indentation-strip-extra ()
+(ekg-deftest ekg-agent-test-adjust-indentation-strip-extra ()
   "Extra leading whitespace in the replacement is stripped."
   (should (equal "    (defun foo ()\n      (bar))"
                  (ekg-agent--adjust-indentation
                   "        (defun foo ()\n          (bar))" 4))))
 
-(ert-deftest ekg-agent-test-adjust-indentation-no-change ()
+(ekg-deftest ekg-agent-test-adjust-indentation-no-change ()
   "Replacement already at the correct indentation is unchanged."
   (should (equal "    (defun foo ()\n      (bar))"
                  (ekg-agent--adjust-indentation
                   "    (defun foo ()\n      (bar))" 4))))
 
-(ert-deftest ekg-agent-test-adjust-indentation-add-whitespace ()
+(ekg-deftest ekg-agent-test-adjust-indentation-add-whitespace ()
   "Whitespace is added when the replacement is under-indented."
   (should (equal "    (defun foo ()\n      (bar))"
                  (ekg-agent--adjust-indentation
                   "  (defun foo ()\n    (bar))" 4))))
 
-(ert-deftest ekg-agent-test-adjust-indentation-empty-lines ()
+(ekg-deftest ekg-agent-test-adjust-indentation-empty-lines ()
   "Empty lines in the replacement are preserved as-is."
   (should (equal "    line1\n\n    line3"
                  (ekg-agent--adjust-indentation
                   "        line1\n\n        line3" 4))))
 
-(ert-deftest ekg-agent-test-adjust-indentation-zero-target ()
+(ekg-deftest ekg-agent-test-adjust-indentation-zero-target ()
   "Adjustment to column zero strips all common indentation."
   (should (equal "(foo)\n  (bar)"
                  (ekg-agent--adjust-indentation
                   "    (foo)\n      (bar)" 0))))
 
-(ert-deftest ekg-agent-test-adjust-indentation-single-line ()
+(ekg-deftest ekg-agent-test-adjust-indentation-single-line ()
   "A single line replacement is adjusted correctly."
   (should (equal "  hello"
                  (ekg-agent--adjust-indentation "      hello" 2))))
 
 ;; Error-as-text macro
 
-(ert-deftest ekg-agent-test-error-as-text-on-error ()
+(ekg-deftest ekg-agent-test-error-as-text-on-error ()
   "Errors are caught and returned as a descriptive string."
   (should (equal "Error: something broke"
                  (ekg-agent--with-error-as-text
                    (error "something broke")))))
 
-(ert-deftest ekg-agent-test-error-as-text-on-success ()
+(ekg-deftest ekg-agent-test-error-as-text-on-success ()
   "Successful results pass through unchanged."
   (should (equal 42
                  (ekg-agent--with-error-as-text
                    (+ 40 2)))))
 
-(ert-deftest ekg-agent-test-status-reminder-adds-prompt-when-overdue ()
+(ekg-deftest ekg-agent-test-status-reminder-adds-prompt-when-overdue ()
   "An overdue session gets a prompt reminder to summarize state."
   (let ((buf (get-buffer-create "*ekg-agent-test-reminder*"))
         (prompt (llm-make-chat-prompt "Work on the task."))
@@ -101,7 +102,7 @@
             (should (string-match-p "what you finished" last-message))))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-status-reminder-skips-recent-status ()
+(ekg-deftest ekg-agent-test-status-reminder-skips-recent-status ()
   "A recent status update does not add another reminder."
   (let ((buf (get-buffer-create "*ekg-agent-test-no-reminder*"))
         (prompt (llm-make-chat-prompt "Work on the task."))
@@ -121,7 +122,7 @@
             (should-not ekg-agent--last-status-reminder-time)))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-status-reminder-repeats-if-ignored ()
+(ekg-deftest ekg-agent-test-status-reminder-repeats-if-ignored ()
   "If the model ignores a reminder, another one is sent later."
   (let ((buf (get-buffer-create "*ekg-agent-test-repeat-reminder*"))
         (prompt (llm-make-chat-prompt "Work on the task."))
@@ -143,27 +144,27 @@
 
 ;; Line ID generation
 
-(ert-deftest ekg-agent-test-line-ids-unique ()
+(ekg-deftest ekg-agent-test-line-ids-unique ()
   "Line IDs for different lines of the same file are unique."
   (let ((ids (mapcar (lambda (n) (ekg-agent--line-id "/tmp/test.txt" n))
                      (number-sequence 1 100))))
     (should (= (length ids)
                (length (delete-dups (copy-sequence ids)))))))
 
-(ert-deftest ekg-agent-test-line-ids-three-chars ()
+(ekg-deftest ekg-agent-test-line-ids-three-chars ()
   "Every line ID is exactly 3 characters."
   (let ((ids (mapcar (lambda (n) (ekg-agent--line-id "/tmp/test.txt" n))
                      (number-sequence 1 50))))
     (should (cl-every (lambda (id) (= 3 (length id))) ids))))
 
-(ert-deftest ekg-agent-test-line-ids-deterministic ()
+(ekg-deftest ekg-agent-test-line-ids-deterministic ()
   "The same path and line number always produce the same ID."
   (should (equal (ekg-agent--line-id "/tmp/test.txt" 42)
                  (ekg-agent--line-id "/tmp/test.txt" 42))))
 
 ;; File read/edit round-trip
 
-(ert-deftest ekg-agent-test-read-file-with-line-ids ()
+(ekg-deftest ekg-agent-test-read-file-with-line-ids ()
   "Reading a file returns content prefixed with 3-char identifiers."
   (let ((path (make-temp-file "ekg-agent-test")))
     (unwind-protect
@@ -177,7 +178,7 @@
                 (should (string-match "\\`...: " line))))))
       (delete-file path))))
 
-(ert-deftest ekg-agent-test-read-file-from-buffer ()
+(ekg-deftest ekg-agent-test-read-file-from-buffer ()
   "Reading a file that is open in a buffer reflects buffer content."
   (let ((path (make-temp-file "ekg-agent-test")))
     (unwind-protect
@@ -194,7 +195,7 @@
               (kill-buffer buf))))
       (delete-file path))))
 
-(ert-deftest ekg-agent-test-read-file-empty-string-args ()
+(ekg-deftest ekg-agent-test-read-file-empty-string-args ()
   "Empty strings for begin/end/range-type are treated as nil."
   (let ((path (make-temp-file "ekg-agent-test")))
     (unwind-protect
@@ -208,7 +209,7 @@
             (should (string-match-p "gamma" full))))
       (delete-file path))))
 
-(ert-deftest ekg-agent-test-write-file-creates-new ()
+(ekg-deftest ekg-agent-test-write-file-creates-new ()
   "write_file creates a new file and returns content with line ids."
   (let ((path (concat (make-temp-file "ekg-agent-test" t) "/new-file.txt")))
     (unwind-protect
@@ -225,7 +226,7 @@
       (when (file-exists-p path)
         (delete-file path)))))
 
-(ert-deftest ekg-agent-test-write-file-overwrites-existing ()
+(ekg-deftest ekg-agent-test-write-file-overwrites-existing ()
   "write_file replaces the content of an existing file."
   (let ((path (make-temp-file "ekg-agent-test")))
     (unwind-protect
@@ -238,7 +239,7 @@
                            (buffer-string)))))
       (delete-file path))))
 
-(ert-deftest ekg-agent-test-write-file-updates-buffer ()
+(ekg-deftest ekg-agent-test-write-file-updates-buffer ()
   "write_file updates an open buffer instead of writing to disk."
   (let ((path (make-temp-file "ekg-agent-test")))
     (unwind-protect
@@ -253,7 +254,7 @@
             (kill-buffer buf)))
       (delete-file path))))
 
-(ert-deftest ekg-agent-test-edit-file-round-trip ()
+(ekg-deftest ekg-agent-test-edit-file-round-trip ()
   "Editing a file replaces the identified region and returns context."
   (let ((path (make-temp-file "ekg-agent-test")))
     (unwind-protect
@@ -273,7 +274,7 @@
               (should (string-match-p "line three" (buffer-string))))))
       (delete-file path))))
 
-(ert-deftest ekg-agent-test-edit-file-adjusts-indentation ()
+(ekg-deftest ekg-agent-test-edit-file-adjusts-indentation ()
   "Editing a file corrects over-indented replacement text."
   (let ((path (make-temp-file "ekg-agent-test")))
     (unwind-protect
@@ -298,7 +299,6 @@
 ;; predetermined tool calls, then verify that tools execute correctly
 ;; and the agent loop terminates as expected.
 
-(require 'ekg-test-utils)
 (require 'llm-fake)
 
 (defun ekg-agent-test--extract-id (read-output line-index)
@@ -353,7 +353,7 @@ result when the agent finishes."
                                          "test-agent"))))
        (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-agent-reads-and-edits-file ()
+(ekg-deftest ekg-agent-test-agent-reads-and-edits-file ()
   "The agent loop reads a file, edits it, and ends."
   (let ((path (make-temp-file "ekg-agent-int-test")))
     (unwind-protect
@@ -395,7 +395,7 @@ result when the agent finishes."
               (should (string-match-p "return True" (buffer-string))))))
       (delete-file path))))
 
-(ekg-deftest ekg-agent-test-agent-creates-note ()
+(ekg-deftest-with-db ekg-agent-test-agent-creates-note ()
   (ekg-agent-test--with-mock-agent
       (list
        ;; Iteration 1: create a note
@@ -416,7 +416,7 @@ result when the agent finishes."
     (should (= 1 (length notes)))
     (should (string-match-p "Test note content" (ekg-note-text (car notes))))))
 
-(ekg-deftest ekg-agent-test-append-to-note ()
+(ekg-deftest-with-db ekg-agent-test-append-to-note ()
   "Appending to a note adds content without log contamination."
   (let* ((note (ekg-note-create :text "Original content."
                                 :mode 'org-mode
@@ -453,7 +453,7 @@ result when the agent finishes."
       (should-not (string-match-p "Waiting for LLM" text))
       (should-not (string-match-p "^[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}" text)))))
 
-(ert-deftest ekg-agent-test-agent-run-command ()
+(ekg-deftest ekg-agent-test-agent-run-command ()
   "The run_command tool executes a shell command and returns output."
   (let (result)
     (ekg-agent--run-command (lambda (r) (setq result r)) "echo hello-world")
@@ -461,7 +461,7 @@ result when the agent finishes."
     (should (string-match-p "Exit code: 0" result))
     (should (string-match-p "hello-world" result))))
 
-(ert-deftest ekg-agent-test-agent-run-command-failure ()
+(ekg-deftest ekg-agent-test-agent-run-command-failure ()
   "The run_command tool reports non-zero exit codes."
   (let (result)
     (ekg-agent--run-command (lambda (r) (setq result r)) "exit 42")
@@ -470,32 +470,32 @@ result when the agent finishes."
 
 ;; Buffer line ID generation
 
-(ert-deftest ekg-agent-test-buffer-line-ids-unique ()
+(ekg-deftest ekg-agent-test-buffer-line-ids-unique ()
   "Buffer line IDs for different lines of the same buffer are unique."
   (let ((ids (mapcar (lambda (n) (ekg-agent--buffer-line-id "*test-buf*" n))
                      (number-sequence 1 100))))
     (should (= (length ids)
                (length (delete-dups (copy-sequence ids)))))))
 
-(ert-deftest ekg-agent-test-buffer-line-ids-three-chars ()
+(ekg-deftest ekg-agent-test-buffer-line-ids-three-chars ()
   "Every buffer line ID is exactly 3 characters."
   (let ((ids (mapcar (lambda (n) (ekg-agent--buffer-line-id "*test-buf*" n))
                      (number-sequence 1 50))))
     (should (cl-every (lambda (id) (= 3 (length id))) ids))))
 
-(ert-deftest ekg-agent-test-buffer-line-ids-deterministic ()
+(ekg-deftest ekg-agent-test-buffer-line-ids-deterministic ()
   "The same buffer name and line number always produce the same ID."
   (should (equal (ekg-agent--buffer-line-id "*test*" 42)
                  (ekg-agent--buffer-line-id "*test*" 42))))
 
-(ert-deftest ekg-agent-test-buffer-line-ids-differ-from-file ()
+(ekg-deftest ekg-agent-test-buffer-line-ids-differ-from-file ()
   "Buffer line IDs differ from file line IDs for the same line number."
   (should-not (equal (ekg-agent--buffer-line-id "/tmp/test.txt" 1)
                      (ekg-agent--line-id "/tmp/test.txt" 1))))
 
 ;; List buffers
 
-(ert-deftest ekg-agent-test-list-buffers ()
+(ekg-deftest ekg-agent-test-list-buffers ()
   "Listing buffers returns visible buffers with metadata."
   (let ((buf (get-buffer-create "*ekg-agent-test-list*")))
     (unwind-protect
@@ -504,7 +504,7 @@ result when the agent finishes."
           (should (string-match-p "\\*ekg-agent-test-list\\*" result)))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-list-buffers-with-filter ()
+(ekg-deftest ekg-agent-test-list-buffers-with-filter ()
   "Listing buffers with a regex filter returns only matching buffers."
   (let ((buf1 (get-buffer-create "*ekg-agent-test-alpha*"))
         (buf2 (get-buffer-create "*ekg-agent-test-beta*")))
@@ -515,7 +515,7 @@ result when the agent finishes."
       (kill-buffer buf1)
       (kill-buffer buf2))))
 
-(ert-deftest ekg-agent-test-list-buffers-excludes-internal ()
+(ekg-deftest ekg-agent-test-list-buffers-excludes-internal ()
   "Internal buffers (names starting with space) are excluded."
   (let ((buf (get-buffer-create " *ekg-agent-internal*")))
     (unwind-protect
@@ -525,7 +525,7 @@ result when the agent finishes."
 
 ;; Read buffer
 
-(ert-deftest ekg-agent-test-read-buffer-with-line-ids ()
+(ekg-deftest ekg-agent-test-read-buffer-with-line-ids ()
   "Reading a buffer returns content prefixed with 3-char identifiers and positions."
   (let ((buf (get-buffer-create "*ekg-agent-test-read*")))
     (unwind-protect
@@ -542,7 +542,7 @@ result when the agent finishes."
                 (should (string-match "\\`...: " line))))))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-read-buffer-range-by-line-number ()
+(ekg-deftest ekg-agent-test-read-buffer-range-by-line-number ()
   "Reading a buffer with line number range returns only that range."
   (let ((buf (get-buffer-create "*ekg-agent-test-range*")))
     (unwind-protect
@@ -558,7 +558,7 @@ result when the agent finishes."
             (should-not (string-match-p "line4" result))))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-read-buffer-range-by-identifier ()
+(ekg-deftest ekg-agent-test-read-buffer-range-by-identifier ()
   "Reading a buffer with identifier range returns the correct range."
   (let ((buf (get-buffer-create "*ekg-agent-test-id-range*")))
     (unwind-protect
@@ -578,7 +578,7 @@ result when the agent finishes."
             (should-not (string-match-p "ddd" result))))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-read-buffer-returns-positions ()
+(ekg-deftest ekg-agent-test-read-buffer-returns-positions ()
   "The begin_pos and end_pos in read_buffer output match actual buffer positions."
   (let ((buf (get-buffer-create "*ekg-agent-test-pos*")))
     (unwind-protect
@@ -594,14 +594,14 @@ result when the agent finishes."
               (should (= 7 begin-pos)))))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-read-buffer-nonexistent ()
+(ekg-deftest ekg-agent-test-read-buffer-nonexistent ()
   "Reading a nonexistent buffer returns an error string."
   (let ((result (ekg-agent--read-buffer "*no-such-buffer-exists*")))
     (should (string-match-p "Error:" result))))
 
 ;; Edit buffer
 
-(ert-deftest ekg-agent-test-edit-buffer-round-trip ()
+(ekg-deftest ekg-agent-test-edit-buffer-round-trip ()
   "Editing a buffer replaces the identified region and returns context."
   (let ((buf (get-buffer-create "*ekg-agent-test-edit*")))
     (unwind-protect
@@ -622,7 +622,7 @@ result when the agent finishes."
               (should (string-match-p "line three" (buffer-string))))))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-edit-buffer-adjusts-indentation ()
+(ekg-deftest ekg-agent-test-edit-buffer-adjusts-indentation ()
   "Editing a buffer corrects over-indented replacement text."
   (let ((buf (get-buffer-create "*ekg-agent-test-edit-indent*")))
     (unwind-protect
@@ -640,7 +640,7 @@ result when the agent finishes."
               (should (string-match-p "^  new content" (buffer-string))))))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-edit-buffer-nonexistent ()
+(ekg-deftest ekg-agent-test-edit-buffer-nonexistent ()
   "Editing a nonexistent buffer returns an error string."
   (let ((result (ekg-agent--edit-buffer "*no-such-buffer*"
                                        "abc" "text" "abc" "text" "new")))
@@ -648,7 +648,7 @@ result when the agent finishes."
 
 ;; Run interactive command
 
-(ert-deftest ekg-agent-test-run-interactive-command-with-point ()
+(ekg-deftest ekg-agent-test-run-interactive-command-with-point ()
   "Running an interactive command at a point position works."
   (let ((buf (get-buffer-create "*ekg-agent-test-cmd*")))
     (unwind-protect
@@ -664,7 +664,7 @@ result when the agent finishes."
               (should (string-match-p "HELLO" (buffer-string))))))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-run-interactive-command-with-line-id ()
+(ekg-deftest ekg-agent-test-run-interactive-command-with-line-id ()
   "Running an interactive command via line identifier works."
   (let ((buf (get-buffer-create "*ekg-agent-test-cmd-id*")))
     (unwind-protect
@@ -683,7 +683,7 @@ result when the agent finishes."
               (should (string-match-p "first" (buffer-string))))))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-run-interactive-command-returns-context ()
+(ekg-deftest ekg-agent-test-run-interactive-command-returns-context ()
   "The interactive command tool returns buffer content around the point."
   (let ((buf (get-buffer-create "*ekg-agent-test-cmd-ctx*")))
     (unwind-protect
@@ -699,7 +699,7 @@ result when the agent finishes."
             (should (string-match-p "line1" result))))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-run-interactive-command-post-move-context ()
+(ekg-deftest ekg-agent-test-run-interactive-command-post-move-context ()
   "Context is centered on the post-command point, not the original position."
   (let ((buf (get-buffer-create "*ekg-agent-test-cmd-move*")))
     (unwind-protect
@@ -722,13 +722,13 @@ result when the agent finishes."
             (should-not (string-match-p "line-01" result))))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-run-interactive-command-nonexistent-buffer ()
+(ekg-deftest ekg-agent-test-run-interactive-command-nonexistent-buffer ()
   "Running a command in a nonexistent buffer returns an error string."
   (let ((result (ekg-agent--run-interactive-command
                  "*no-such-buffer*" "forward-char" "1" nil nil)))
     (should (string-match-p "Error:" result))))
 
-(ert-deftest ekg-agent-test-run-interactive-command-bad-command ()
+(ekg-deftest ekg-agent-test-run-interactive-command-bad-command ()
   "Running a non-interactive function returns an error string."
   (let ((buf (get-buffer-create "*ekg-agent-test-bad-cmd*")))
     (unwind-protect
@@ -738,7 +738,7 @@ result when the agent finishes."
           (should (string-match-p "Error:" result)))
       (kill-buffer buf))))
 
-(ert-deftest ekg-agent-test-resolve-buffer-point-precedence ()
+(ekg-deftest ekg-agent-test-resolve-buffer-point-precedence ()
   "When both point and line_id are given, point takes precedence."
   (let ((buf (get-buffer-create "*ekg-agent-test-precedence*")))
     (unwind-protect
@@ -758,7 +758,7 @@ result when the agent finishes."
 
 ;; Agent integration: buffer read + edit
 
-(ert-deftest ekg-agent-test-agent-reads-and-edits-buffer ()
+(ekg-deftest ekg-agent-test-agent-reads-and-edits-buffer ()
   "The agent loop reads a buffer, edits it, and ends."
   (let ((buf (get-buffer-create "*ekg-agent-test-buf-int*")))
     (unwind-protect
@@ -795,7 +795,7 @@ result when the agent finishes."
 
 ;; Web rendering / browsing / search
 
-(ert-deftest ekg-agent-test-web-render-html-basic ()
+(ekg-deftest ekg-agent-test-web-render-html-basic ()
   "Rendering simple HTML produces readable text."
   (let ((result (ekg-agent--web-render-html
                  "<html><body><p>Hello world</p></body></html>"
@@ -803,7 +803,7 @@ result when the agent finishes."
     (should (stringp result))
     (should (string-match-p "Hello world" result))))
 
-(ert-deftest ekg-agent-test-web-render-html-truncation ()
+(ekg-deftest ekg-agent-test-web-render-html-truncation ()
   "Content exceeding `ekg-agent-web-max-chars' is truncated."
   (let* ((ekg-agent-web-max-chars 50)
          (long-text (make-string 200 ?x))
@@ -812,26 +812,26 @@ result when the agent finishes."
     (should (<= (length result) (+ 50 100)))  ; truncated text + notice
     (should (string-match-p "\\[Content truncated" result))))
 
-(ert-deftest ekg-agent-test-web-render-html-empty ()
+(ekg-deftest ekg-agent-test-web-render-html-empty ()
   "Rendering empty HTML returns a non-erroring result."
   (let ((result (ekg-agent--web-render-html
                  "<html><body></body></html>"
                  "https://example.com")))
     (should (stringp result))))
 
-(ert-deftest ekg-agent-test-web-browse-rejects-non-http ()
+(ekg-deftest ekg-agent-test-web-browse-rejects-non-http ()
   "Non-http(s) URLs are rejected with an error message."
   (let (result)
     (ekg-agent--web-browse (lambda (r) (setq result r)) "ftp://example.com/file")
     (should (string-match-p "Error:.*Only http" result))))
 
-(ert-deftest ekg-agent-test-web-browse-rejects-file-url ()
+(ekg-deftest ekg-agent-test-web-browse-rejects-file-url ()
   "file:// URLs are rejected."
   (let (result)
     (ekg-agent--web-browse (lambda (r) (setq result r)) "file:///etc/passwd")
     (should (string-match-p "Error:.*Only http" result))))
 
-(ert-deftest ekg-agent-test-web-browse-success ()
+(ekg-deftest ekg-agent-test-web-browse-success ()
   "A successful fetch renders and returns page content."
   (let (result)
     (cl-letf (((symbol-function 'url-retrieve)
@@ -850,7 +850,7 @@ result when the agent finishes."
     (should (string-match-p "Search result" result))
     (should (string-match-p "Content from https://example.com/test" result))))
 
-(ert-deftest ekg-agent-test-web-browse-http-error ()
+(ekg-deftest ekg-agent-test-web-browse-http-error ()
   "HTTP errors from url-retrieve are reported."
   (let (result)
     (cl-letf (((symbol-function 'url-retrieve)
@@ -863,7 +863,7 @@ result when the agent finishes."
                              "https://example.com/missing"))
     (should (string-match-p "Error fetching URL" result))))
 
-(ert-deftest ekg-agent-test-web-search-constructs-url ()
+(ekg-deftest ekg-agent-test-web-search-constructs-url ()
   "Web search passes the correctly constructed search URL to web-browse."
   (let (captured-url result)
     (cl-letf (((symbol-function 'ekg-agent--web-browse)
@@ -876,7 +876,7 @@ result when the agent finishes."
     (should (string-match-p "lisp" captured-url))
     (should (stringp result))))
 
-(ert-deftest ekg-agent-test-web-search-hexifies-query ()
+(ekg-deftest ekg-agent-test-web-search-hexifies-query ()
   "Web search properly hex-encodes special characters in the query."
   (let (captured-url)
     (cl-letf (((symbol-function 'ekg-agent--web-browse)
@@ -891,7 +891,7 @@ result when the agent finishes."
                                      "https?://[^?]*\\?" ""
                                      captured-url)))))
 
-(ert-deftest ekg-agent-test-web-search-custom-prefix ()
+(ekg-deftest ekg-agent-test-web-search-custom-prefix ()
   "Web search respects a custom `eww-search-prefix'."
   (let ((eww-search-prefix "https://google.com/search?q=")
         captured-url)

--- a/ekg-apple-notes-test.el
+++ b/ekg-apple-notes-test.el
@@ -14,7 +14,7 @@
 
 ;;; ---- Tag Conversion Tests ----
 
-(ert-deftest ekg-apple-notes-test-tags-to-metadata ()
+(ekg-deftest ekg-apple-notes-test-tags-to-metadata ()
   "Tags are converted to one Tag: line per tag."
   (let ((ekg-hidden-tags '("trash" "draft")))
     (should (equal "Tag: food\nTag: recipes"
@@ -23,35 +23,35 @@
     (should (equal "Tag: food"
                    (ekg-apple-notes--tags-to-metadata '("food" "trash"))))))
 
-(ert-deftest ekg-apple-notes-test-tags-to-metadata-empty ()
+(ekg-deftest ekg-apple-notes-test-tags-to-metadata-empty ()
   "No metadata lines when there are no visible tags."
   (let ((ekg-hidden-tags '("trash")))
     (should-not (ekg-apple-notes--tags-to-metadata '("trash")))))
 
-(ert-deftest ekg-apple-notes-test-tags-to-metadata-spaces ()
+(ekg-deftest ekg-apple-notes-test-tags-to-metadata-spaces ()
   "Tags with spaces are preserved as-is."
   (let ((ekg-hidden-tags nil))
     (should (equal "Tag: my tag"
                    (ekg-apple-notes--tags-to-metadata '("my tag"))))))
 
-(ert-deftest ekg-apple-notes-test-parse-tags-from-body ()
+(ekg-deftest ekg-apple-notes-test-parse-tags-from-body ()
   "Parse Tag: lines from HTML body."
   (should (equal '("food" "date/2024-01-01" "my tag")
                  (ekg-apple-notes--parse-tags-from-body
                   "<div>some content</div>\n<div>Tag: food</div>\n<div>Tag: date/2024-01-01</div>\n<div>Tag: my tag</div>"))))
 
-(ert-deftest ekg-apple-notes-test-parse-tags-plain-text ()
+(ekg-deftest ekg-apple-notes-test-parse-tags-plain-text ()
   "Parse Tag: lines from plain text body."
   (should (equal '("food" "recipes")
                  (ekg-apple-notes--parse-tags-from-body
                   "some content\nTag: food\nTag: recipes"))))
 
-(ert-deftest ekg-apple-notes-test-parse-tags-no-line ()
+(ekg-deftest ekg-apple-notes-test-parse-tags-no-line ()
   "Return nil when there are no Tag: lines."
   (should-not (ekg-apple-notes--parse-tags-from-body
                "<div>just content without tags</div>")))
 
-(ert-deftest ekg-apple-notes-test-remove-tags-line ()
+(ekg-deftest ekg-apple-notes-test-remove-tags-line ()
   "Remove Tag: lines from text."
   (should (equal "some content"
                  (ekg-apple-notes--remove-tags-line
@@ -59,21 +59,21 @@
 
 ;;; ---- HTML Tag Removal Tests ----
 
-(ert-deftest ekg-apple-notes-test-remove-tags-html ()
+(ekg-deftest ekg-apple-notes-test-remove-tags-html ()
   "Tag divs and spacer are removed from HTML."
   (should (equal "<div>content</div>"
                  (string-trim
                   (ekg-apple-notes--remove-tags-html
                    "<div>content</div>\n<div><br></div>\n<div>Tag: food</div>\n<div>Tag: recipes</div>")))))
 
-(ert-deftest ekg-apple-notes-test-remove-tags-html-no-spacer ()
+(ekg-deftest ekg-apple-notes-test-remove-tags-html-no-spacer ()
   "Tag divs without spacer are removed."
   (should (equal "<div>content</div>"
                  (string-trim
                   (ekg-apple-notes--remove-tags-html
                    "<div>content</div>\n<div>Tag: food</div>")))))
 
-(ert-deftest ekg-apple-notes-test-remove-tags-html-spaces-in-tag ()
+(ekg-deftest ekg-apple-notes-test-remove-tags-html-spaces-in-tag ()
   "Tag divs with spaces in tag names are removed."
   (should (equal "<div>content</div>"
                  (string-trim
@@ -82,32 +82,32 @@
 
 ;;; ---- Resource Parsing Tests ----
 
-(ert-deftest ekg-apple-notes-test-parse-resource-from-body ()
+(ekg-deftest ekg-apple-notes-test-parse-resource-from-body ()
   "Parse Resource: line from HTML body."
   (should (equal "https://example.com/page"
                  (ekg-apple-notes--parse-resource-from-body
                   "<div>Resource: https://example.com/page</div>\n<div><br></div>\n<div>content</div>"))))
 
-(ert-deftest ekg-apple-notes-test-parse-resource-from-body-none ()
+(ekg-deftest ekg-apple-notes-test-parse-resource-from-body-none ()
   "Return nil when there is no Resource: line."
   (should-not (ekg-apple-notes--parse-resource-from-body
                "<div>just content</div>")))
 
-(ert-deftest ekg-apple-notes-test-remove-resource-html ()
+(ekg-deftest ekg-apple-notes-test-remove-resource-html ()
   "Resource div and spacer are removed from HTML."
   (should (equal "<div>content</div>"
                  (string-trim
                   (ekg-apple-notes--remove-resource-html
                    "<div>Resource: https://example.com</div>\n<div><br></div>\n<div>content</div>")))))
 
-(ert-deftest ekg-apple-notes-test-remove-resource-html-no-spacer ()
+(ekg-deftest ekg-apple-notes-test-remove-resource-html-no-spacer ()
   "Resource div without spacer is removed."
   (should (equal "<div>content</div>"
                  (string-trim
                   (ekg-apple-notes--remove-resource-html
                    "<div>Resource: https://example.com</div>\n<div>content</div>")))))
 
-(ert-deftest ekg-apple-notes-test-to-html-includes-resource ()
+(ekg-deftest ekg-apple-notes-test-to-html-includes-resource ()
   "Notes with URI IDs include a Resource: line at the top of exported HTML."
   (skip-unless (executable-find "pandoc"))
   (let* ((ekg-hidden-tags nil)
@@ -117,7 +117,7 @@
          (html (ekg-apple-notes--to-html note)))
     (should (string-prefix-p "<div>Resource: https://example.com/page</div>" html))))
 
-(ert-deftest ekg-apple-notes-test-to-html-no-resource-for-numeric-id ()
+(ekg-deftest ekg-apple-notes-test-to-html-no-resource-for-numeric-id ()
   "Notes with numeric IDs do not include a Resource: line."
   (skip-unless (executable-find "pandoc"))
   (let* ((ekg-hidden-tags nil)
@@ -129,43 +129,43 @@
 
 ;;; ---- HTML Processing Tests ----
 
-(ert-deftest ekg-apple-notes-test-html-delink ()
+(ekg-deftest ekg-apple-notes-test-html-delink ()
   "Links are converted to markdown [text](url) format."
   (should (equal "[Example](https://example.com)"
                  (ekg-apple-notes--html-delink
                   "<a href=\"https://example.com\">Example</a>"))))
 
-(ert-deftest ekg-apple-notes-test-html-delink-multiple ()
+(ekg-deftest ekg-apple-notes-test-html-delink-multiple ()
   "Multiple links are all converted."
   (should (equal "Visit [A](http://a.com) and [B](http://b.com)"
                  (ekg-apple-notes--html-delink
                   "Visit <a href=\"http://a.com\">A</a> and <a href=\"http://b.com\">B</a>"))))
 
-(ert-deftest ekg-apple-notes-test-normalize-divs ()
+(ekg-deftest ekg-apple-notes-test-normalize-divs ()
   "Div wrappers are converted to paragraphs."
   (should (equal "<p>First</p>\n<p>Second</p>"
                  (ekg-apple-notes--normalize-divs
                   "<div>First</div>\n<div>Second</div>"))))
 
-(ert-deftest ekg-apple-notes-test-normalize-divs-br-spacer ()
+(ekg-deftest ekg-apple-notes-test-normalize-divs-br-spacer ()
   "Div-wrapped br spacers are removed."
   (should (equal "<p>First</p>\n\n<p>Second</p>"
                  (ekg-apple-notes--normalize-divs
                   "<div>First</div>\n<div><br></div>\n<div>Second</div>"))))
 
-(ert-deftest ekg-apple-notes-test-normalize-divs-trailing-br ()
+(ekg-deftest ekg-apple-notes-test-normalize-divs-trailing-br ()
   "Trailing br inside divs is stripped to avoid pandoc backslashes."
   (should (equal "<p>First</p>\n<p>Second</p>\n<p>Third</p>"
                  (ekg-apple-notes--normalize-divs
                   "<div>First<br></div>\n<div>Second<br/></div>\n<div>Third<br /></div>"))))
 
-(ert-deftest ekg-apple-notes-test-relink-org ()
+(ekg-deftest ekg-apple-notes-test-relink-org ()
   "Markdown links are converted to org links."
   (should (equal "Visit [[https://example.com][Example]]"
                  (ekg-apple-notes--relink-org
                   "Visit [Example](https://example.com)"))))
 
-(ert-deftest ekg-apple-notes-test-relink-org-multiple ()
+(ekg-deftest ekg-apple-notes-test-relink-org-multiple ()
   "Multiple markdown links are all converted to org links."
   (should (equal "[[http://a.com][A]] and [[http://b.com][B]]"
                  (ekg-apple-notes--relink-org
@@ -174,25 +174,25 @@
 ;;; ---- Pandoc Integration Tests ----
 ;; These tests require pandoc to be installed.
 
-(ert-deftest ekg-apple-notes-test-pandoc-org-to-html ()
+(ekg-deftest ekg-apple-notes-test-pandoc-org-to-html ()
   "Org text is converted to HTML."
   (skip-unless (executable-find "pandoc"))
   (let ((html (ekg-apple-notes--pandoc "Some *bold* text" "org" "html")))
     (should (string-match-p "<strong>bold</strong>" html))))
 
-(ert-deftest ekg-apple-notes-test-pandoc-html-to-org ()
+(ekg-deftest ekg-apple-notes-test-pandoc-html-to-org ()
   "HTML is converted to org text."
   (skip-unless (executable-find "pandoc"))
   (let ((org (ekg-apple-notes--pandoc "<p>Some <b>bold</b> text</p>" "html" "org")))
     (should (string-match-p "\\*bold\\*" org))))
 
-(ert-deftest ekg-apple-notes-test-pandoc-md-to-html ()
+(ekg-deftest ekg-apple-notes-test-pandoc-md-to-html ()
   "Markdown is converted to HTML."
   (skip-unless (executable-find "pandoc"))
   (let ((html (ekg-apple-notes--pandoc "Some **bold** text" "markdown" "html")))
     (should (string-match-p "<strong>bold</strong>" html))))
 
-(ert-deftest ekg-apple-notes-test-pandoc-html-to-md ()
+(ekg-deftest ekg-apple-notes-test-pandoc-html-to-md ()
   "HTML is converted to markdown."
   (skip-unless (executable-find "pandoc"))
   (let ((md (ekg-apple-notes--pandoc "<p>Some <b>bold</b> text</p>" "html" "markdown")))
@@ -200,7 +200,7 @@
 
 ;;; ---- ISO Time Parsing ----
 
-(ert-deftest ekg-apple-notes-test-parse-iso-time ()
+(ekg-deftest ekg-apple-notes-test-parse-iso-time ()
   "ISO 8601 timestamps are parsed to epoch integers."
   (let ((epoch (ekg-apple-notes--parse-iso-time "2026-02-24T14:30:00")))
     (should (integerp epoch))

--- a/ekg-denote-test.el
+++ b/ekg-denote-test.el
@@ -28,13 +28,13 @@
 (require 'ekg-denote)
 (require 'cl-lib)
 
-(ert-deftest ekg-denote-test-sublist-keywords ()
+(ekg-deftest ekg-denote-test-sublist-keywords ()
   "Combined length of the sublist keywords is as per the allowed combined length argument."
   (should (equal '("kw1") (ekg-denote-sublist-keywords '("kw1" "kw2" "kw 3") 4)))
   (should (equal '("kw1" "kw2") (ekg-denote-sublist-keywords '("kw1" "kw2" "kw 3") 8)))
   (should (equal '("kw1" "kw2" "kw 3") (ekg-denote-sublist-keywords '("kw1" "kw2" "kw 3") 13))))
 
-(ert-deftest ekg-denote-test-notes-having-duplicate-creation-time ()
+(ekg-deftest ekg-denote-test-notes-having-duplicate-creation-time ()
   "Notes with duplicate creation time should error."
   (let* ((time (time-convert (current-time) 'integer))
 	     (note1 (make-ekg-note :id "ID1" :creation-time time))
@@ -42,7 +42,7 @@
 	     (notes (list note1 note2)))
     (should-error (ekg-denote-assert-notes-have-unique-creation-time notes))))
 
-(ert-deftest ekg-denote-test-notes-having-unique-creation-tiem ()
+(ekg-deftest ekg-denote-test-notes-having-unique-creation-tiem ()
   "Notes with unique creation time should not error."
   (let* ((time (time-convert (current-time) 'integer))
 	     (note1 (make-ekg-note :id "ID1" :creation-time time))
@@ -50,14 +50,14 @@
 	     (notes (list note1 note2)))
     (should-not (ekg-denote-assert-notes-have-unique-creation-time notes))))
 
-(ert-deftest ekg-denote-test-notes-missing-creation-time ()
+(ekg-deftest ekg-denote-test-notes-missing-creation-time ()
   "Notes missing creation time should error."
   (let* ((time (time-convert (current-time) 'integer))
 	     (note1 (make-ekg-note :id "ID1" :creation-time time))
 	     (note2 (make-ekg-note :id "ID2")))
     (should-error (ekg-denote-assert-notes-have-creation-time notes))))
 
-(ert-deftest ekg-denote-test-notes-not-missing-creation-time ()
+(ekg-deftest ekg-denote-test-notes-not-missing-creation-time ()
   "Notes having creation time should not error."
   (let* ((time (time-convert (current-time) 'integer))
 	     (note1 (make-ekg-note :id "ID1" :creation-time time))
@@ -65,7 +65,7 @@
 	     (notes (list note1 note2)))
     (should-not (ekg-denote-assert-notes-have-creation-time notes))))
 
-(ert-deftest ekg-denote-test-create ()
+(ekg-deftest ekg-denote-test-create ()
   "Verify creation of `ekg-denote' against given ekg note."
 
                                         ; date tag is removed.
@@ -156,7 +156,7 @@ Enforces single match."
     (should (length= triples 1))
     (ekg-get-note-with-id (car (car triples)))))
 
-(ekg-deftest ekg-denote-test-export ()
+(ekg-deftest-with-db ekg-denote-test-export ()
   "Verify export."
   (ekg-denote-add-schema)
   (let ((denote-directory (make-temp-file "denote" t)))
@@ -183,14 +183,14 @@ Enforces single match."
     (should (ekg-test--matching-denote "__updatedtag"))
     (should-not (ekg-test--matching-denote "__portfolio"))))
 
-(ekg-deftest ekg-denote-test-last-export ()
+(ekg-deftest-with-db ekg-denote-test-last-export ()
   "Verify last export time updates."
   (ekg-denote-add-schema)
   (should (= 0 (ekg-denote-get-last-export)))
   (ekg-denote-set-last-export 123)
   (should (= 123 (ekg-denote-get-last-export))))
 
-(ert-deftest ekg-denote-test-create-hidden-tags ()
+(ekg-deftest ekg-denote-test-create-hidden-tags ()
   "Verify that hidden tags are filtered out during denote creation."
   (let* ((time (time-convert (current-time) 'integer))
          (denote-directory "/tmp")

--- a/ekg-llm-test.el
+++ b/ekg-llm-test.el
@@ -24,6 +24,7 @@
 
 ;;; Code:
 (require 'ekg)
+(require 'ekg-test-utils)
 (require 'ekg-llm)
 (require 'ekg-test-utils)
 
@@ -35,7 +36,7 @@
     (delete-region beg end)
     (insert text)))
 
-(ert-deftest ekg-llm-test-create-output-holder ()
+(ekg-deftest ekg-llm-test-create-output-holder ()
   (with-temp-buffer
     (let ((markers (ekg-llm-create-output-holder "BEGIN" "END")))
       (should (equal "BEGIN\n\nEND\n"
@@ -47,7 +48,7 @@
       (should (equal "BEGIN\nvery different text\nEND\n"
                      (substring-no-properties (buffer-string)))))))
 
-(ekg-deftest ekg-llm-test-note-to-text ()
+(ekg-deftest-with-db ekg-llm-test-note-to-text ()
   (let* ((time (current-time))
          (time-str (format-time-string "%Y-%m-%dT%H:%M:%S" time))
          (json-encoding-pretty-print t))

--- a/ekg-logseq-test.el
+++ b/ekg-logseq-test.el
@@ -29,7 +29,7 @@
 (require 'cl-lib)
 (require 'org)
 
-(ert-deftest ekg-logseq-test-to-import-text ()
+(ekg-deftest ekg-logseq-test-to-import-text ()
   (with-temp-buffer
     (insert
      "#+title:test\n#+ekg_export: true\n\n"
@@ -65,21 +65,21 @@
                      "## Heading 1\nid:: def\n"
                      "## Heading 2\nText 2")))))
 
-(ert-deftest ekg-logseq-test-to-import-tags ()
+(ekg-deftest ekg-logseq-test-to-import-tags ()
   (should (equal nil (ekg-logseq--to-import-tags "Just text here, no tags")))
   (should (equal '("foo" "bar baz")
                  (ekg-logseq--to-import-tags "Sometimes I say #foo, sometimes I say #[[bar baz]]"))))
 
-(ert-deftest ekg-logseq-test-to-import-md-id ()
+(ekg-deftest ekg-logseq-test-to-import-md-id ()
   (should (equal nil (ekg-logseq--to-import-md-id "Just text here, no id")))
   (should (equal "123" (ekg-logseq--to-import-md-id "Headline\n  id:: 123\nText"))))
 
-(ert-deftest ekg-logseq-test-to-import-org-id ()
+(ekg-deftest ekg-logseq-test-to-import-org-id ()
   (should (equal nil (ekg-logseq--to-import-org-id "Just text here, no id")))
   (should (equal "123" (ekg-logseq--to-import-org-id "* Headline\n:PROPERTIES:\n:ID: 123\n:END:\nText")))
   (should (equal "123" (ekg-logseq--to-import-org-id "* Headline\n:PROPERTIES:\n:id: 123\n:END:\nText"))))
 
-(ert-deftest ekg-logseq-test-text-to-note ()
+(ekg-deftest ekg-logseq-test-text-to-note ()
   (cl-letf (((symbol-function 'ekg-note-with-id-exists-p) (lambda (id) (or (equal id 321) (equal id 123)))))
     (let ((note (ekg-logseq--text-to-note "tag1" "Headline\n  id:: 123\nText and {{embed ((abc))}} {{embed ((321))}}")))
       (should (equal "Headline\n  id:: 123\nText and  " (ekg-note-text note)))
@@ -91,7 +91,7 @@
       (should (equal 123 (ekg-note-id note)))
       (should (equal '("tag1") (ekg-note-tags note))))))
 
-(ert-deftest ekg-logseq-test-note-to-logseq ()
+(ekg-deftest ekg-logseq-test-note-to-logseq ()
   (let ((note (ekg-note-create :text "line1\nline2\n" :mode 'org-mode :tags '("tag1" "tag2" "tag3"))))
     (setf (ekg-note-id note) 123)
     (setf (ekg-note-modified-time note) 123456789)
@@ -102,7 +102,7 @@
              "- Untitled Note\n  id:: 123\n  ekg_hash:: c696f3d4b296c737155637d3a708d2b986ab6f6f\n  #[[tag1]] #[[tag2]]\n  line1\n  line2\n"
              (ekg-logseq-note-to-logseq-md note "tag3")))))
 
-(ert-deftest ekg-logseq-test-note-to-logseq-with-inlines ()
+(ekg-deftest ekg-logseq-test-note-to-logseq-with-inlines ()
   (let ((note (ekg-note-create :text " " :mode 'org-mode :tags '("tag1" "tag2" "tag3"))))
     (setf (ekg-note-id note) 123)
     (setf (ekg-note-modified-time note) 1682164800)
@@ -121,7 +121,7 @@
                    (ekg-logseq-note-to-logseq-md note "tag3"))))
       (set-time-zone-rule nil))))
 
-(ert-deftest ekg-logseq-test-note-with-resource-and-title-to-logseq ()
+(ekg-deftest ekg-logseq-test-note-with-resource-and-title-to-logseq ()
   (let ((note (ekg-note-create :text "line1\nline2\n" :mode 'org-mode :tags '("tag1" "tag2" "tag3"))))
     (setf (ekg-note-id note) "http://www.example.com")
     (setf (ekg-note-modified-time note) 123456789)
@@ -133,7 +133,7 @@
              "- Title\n  id:: http://www.example.com\n  ekg_hash:: c696f3d4b296c737155637d3a708d2b986ab6f6f\n  #[[tag1]] #[[tag2]]\n  http://www.example.com\n  line1\n  line2\n"
              (ekg-logseq-note-to-logseq-md note "tag3")))))
 
-(ert-deftest ekg-logseq-test-note-to-logseq-org-demotion ()
+(ekg-deftest ekg-logseq-test-note-to-logseq-org-demotion ()
   (let ((note (ekg-note-create :text "* Heading 1\n* Heading 2" :mode 'org-mode :tags nil)))
     (setf (ekg-note-id note) 123)
     (setf (ekg-note-modified-time note) 123456789)
@@ -141,7 +141,7 @@
              "* Untitled Note\n:PROPERTIES:\n:ID: 123\n:EKG_HASH: c3475d5573fae5cd21fb32a9ec2e75a7d0e4d409\n:END:\n** Heading 1\n** Heading 2"
              (ekg-logseq-note-to-logseq-org note "tag3")))))
 
-(ert-deftest ekg-logseq-test-notes-to-logseq ()
+(ekg-deftest ekg-logseq-test-notes-to-logseq ()
   (let ((note1 (ekg-note-create :text "note1" :mode 'org-mode :tags '("a" "b" "c")))
         (note2 (ekg-note-create :text "note2" :mode 'org-mode :tags '("b" "a" "c")))
         (note3 (ekg-note-create :text "" :mode 'org-mode :tags '("a" "b" "c")))
@@ -160,11 +160,11 @@
                     "- Untitled Note\n  id:: 1\n  ekg_hash:: 829ab920fad6efe045caf218b813be4e42ac779a\n  #[[b]] #[[c]]\n  note1")
                    (ekg-logseq-notes-to-logseq (list note1 note2 note3 note4) "a" nil)))))
 
-(ert-deftest ekg-logseq-test-filename-to-tag ()
+(ekg-deftest ekg-logseq-test-filename-to-tag ()
   (should (equal "foo" (ekg-logseq-filename-to-tag "foo.org")))
   (should (equal "foo/bar" (ekg-logseq-filename-to-tag "foo$bar.org"))))
 
-(ekg-deftest ekg-logseq-test-last-import-export ()
+(ekg-deftest-with-db ekg-logseq-test-last-import-export ()
   (ekg-logseq-add-schema)
   (should (= 0 (ekg-logseq-get-last-export)))
   (should (= 0 (ekg-logseq-get-last-import)))
@@ -175,7 +175,7 @@
   (should (= 123 (ekg-logseq-get-last-export)))
   (should (= 456 (ekg-logseq-get-last-import))))
 
-(ekg-deftest ekg-logseq-test-tags-with-notes-modified-since ()
+(ekg-deftest-with-db ekg-logseq-test-tags-with-notes-modified-since ()
   (ekg-logseq-add-schema)
   (cl-flet ((create (time tags)
               (let ((note (ekg-note-create :text "" :mode 'org-mode :tags tags)))

--- a/ekg-org-test.el
+++ b/ekg-org-test.el
@@ -32,7 +32,7 @@
   (when (string-match "\\([0-9]+\\)" result-string)
     (string-to-number (match-string 1 result-string))))
 
-(ekg-deftest ekg-org-test-basic-rendering ()
+(ekg-deftest-with-db ekg-org-test-basic-rendering ()
   "Test that a basic task is rendered correctly."
   (ekg-org-add-schema)
   (let* ((note-id (ekg-org-test-parse-out-id
@@ -56,7 +56,7 @@
     (should (seq-some (lambda (tag) (string-prefix-p ekg-org-state-tag-prefix tag))
                       (ekg-note-tags note)))))
 
-(ekg-deftest ekg-org-test-timestamps ()
+(ekg-deftest-with-db ekg-org-test-timestamps ()
   "Test that deadlines and scheduled dates are stored correctly."
   (ekg-org-add-schema)
   (let* ((deadline "2026-02-01 10:00")
@@ -80,7 +80,7 @@
       (should (plist-get props :org/deadline))
       (should (plist-get props :org/scheduled)))))
 
-(ekg-deftest ekg-org-test-hierarchy ()
+(ekg-deftest-with-db ekg-org-test-hierarchy ()
   "Test that child tasks have correct parent relationship."
   (ekg-org-add-schema)
   (let* ((parent-result (ekg-agent-org--tool-add-item
@@ -108,7 +108,7 @@
       (should (string-match-p "\\* TODO Parent Task" rendered))
       (should (string-match-p "Parent content" rendered)))))
 
-(ekg-deftest ekg-org-test-save-with-virtual-reversed ()
+(ekg-deftest-with-db ekg-org-test-save-with-virtual-reversed ()
   "Test that saving a parent note with org/children doesn't error.
 When a note has children, reading it populates :org/children as a
 virtual-reversed property.  Saving it back must not attempt to
@@ -130,7 +130,7 @@ write that property."
       (should (= (plist-get (ekg-note-properties reloaded) :org/parent)
                  parent-id)))))
 
-(ekg-deftest ekg-org-test-generate-content ()
+(ekg-deftest-with-db ekg-org-test-generate-content ()
   "Test ekg-org-generate-org-content function."
   (ekg-org-add-schema)
   ;; Create multiple tasks
@@ -155,7 +155,7 @@ write that property."
     (should (string-match-p ":project1:" content))
     (should (string-match-p ":project2:" content))))
 
-(ekg-deftest ekg-org-test-archive ()
+(ekg-deftest-with-db ekg-org-test-archive ()
   "Test that archived tasks are handled correctly."
   (ekg-org-add-schema)
   ;; Create normal task
@@ -185,7 +185,7 @@ write that property."
     (let* ((archived-note (ekg-get-note-with-id archived-id)))
       (should (member ekg-org-archive-tag (ekg-note-tags archived-note))))))
 
-(ekg-deftest ekg-org-test-set-status ()
+(ekg-deftest-with-db ekg-org-test-set-status ()
   "Test changing status of a task."
   (ekg-org-add-schema)
   (let* ((note-result (ekg-agent-org--tool-add-item
@@ -213,7 +213,7 @@ write that property."
       (setq start (match-end 0)))
     count))
 
-(ekg-deftest ekg-org-test-list-items ()
+(ekg-deftest-with-db ekg-org-test-list-items ()
   "Test listing tasks."
   (ekg-org-add-schema)
   (ekg-agent-org--tool-add-item "Task 1" "C1" nil nil "TODO" nil nil)
@@ -227,7 +227,7 @@ write that property."
     (should (= (ekg-org-test-count-tasks todos) 1))
     (should (string-match-p "Task 1" todos))))
 
-(ekg-deftest ekg-org-test-tag-handling ()
+(ekg-deftest-with-db ekg-org-test-tag-handling ()
   "Test that org/task and org/state tags are handled correctly."
   (ekg-org-add-schema)
   (let* ((note-id
@@ -296,7 +296,7 @@ Returns the note ID."
                          title)
              return (ekg-note-id note))))
 
-(ekg-deftest ekg-org-test-view-basic-hierarchy ()
+(ekg-deftest-with-db ekg-org-test-view-basic-hierarchy ()
   "Test that the view renders a parent with children in order."
   (ekg-org-add-schema)
   (let* ((parent-id (ekg-org-test--add-task "Parent"))
@@ -307,7 +307,7 @@ Returns the note ID."
       (should (equal headings
                      '((1 "Parent") (2 "Child A") (2 "Child B")))))))
 
-(ekg-deftest ekg-org-test-view-body-fontified ()
+(ekg-deftest-with-db ekg-org-test-view-body-fontified ()
   "Test that org body text in the view is fontified, not raw text."
   (ekg-org-add-schema)
   (ekg-agent-org--tool-add-item
@@ -323,7 +323,7 @@ Returns the note ID."
       (should face)
       (should-not (eq face 'ekg-org-view-body)))))
 
-(ekg-deftest ekg-org-test-view-multiple-top-level ()
+(ekg-deftest-with-db ekg-org-test-view-multiple-top-level ()
   "Test that multiple top-level tasks all appear."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "First")
@@ -336,7 +336,7 @@ Returns the note ID."
     (should (member "Second" titles))
     (should (member "Third" titles))))
 
-(ekg-deftest ekg-org-test-view-collapse ()
+(ekg-deftest-with-db ekg-org-test-view-collapse ()
   "Test that collapsing a parent hides its children."
   (ekg-org-add-schema)
   (let* ((parent-id (ekg-org-test--add-task "Parent"))
@@ -349,7 +349,7 @@ Returns the note ID."
     (should (equal (ekg-org-test--view-headings)
                    '((1 "Parent"))))))
 
-(ekg-deftest ekg-org-test-view-archive-removes-from-view ()
+(ekg-deftest-with-db ekg-org-test-view-archive-removes-from-view ()
   "Test that archiving a task removes it from the active view."
   (ekg-org-add-schema)
   (let ((id (ekg-org-test--add-task "To Archive")))
@@ -363,7 +363,7 @@ Returns the note ID."
     (ekg-org-view)
     (should-not (member "To Archive" (ekg-org-test--view-titles)))))
 
-(ekg-deftest ekg-org-test-view-archive-appears-in-archive-view ()
+(ekg-deftest-with-db ekg-org-test-view-archive-appears-in-archive-view ()
   "Test that archived tasks appear in the archive view."
   (ekg-org-add-schema)
   (let ((id (ekg-org-test--add-task "Archived Task")))
@@ -384,7 +384,7 @@ Returns the note ID."
           (forward-line 1))
         (should (member "Archived Task" titles))))))
 
-(ekg-deftest ekg-org-test-view-promote ()
+(ekg-deftest-with-db ekg-org-test-view-promote ()
   "Test that promoting a child makes it a sibling of its parent."
   (ekg-org-add-schema)
   (let* ((parent-id (ekg-org-test--add-task "Parent"))
@@ -401,7 +401,7 @@ Returns the note ID."
       (should (equal (assoc 1 headings) '(1 "Parent")))
       (should (member '(1 "Child") headings)))))
 
-(ekg-deftest ekg-org-test-view-demote ()
+(ekg-deftest-with-db ekg-org-test-view-demote ()
   "Test that demoting a task makes it a child of the previous sibling."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "First")
@@ -417,7 +417,7 @@ Returns the note ID."
     (should (equal (car headings) '(1 "First")))
     (should (equal (cadr headings) '(2 "Second")))))
 
-(ekg-deftest ekg-org-test-view-move-up ()
+(ekg-deftest-with-db ekg-org-test-view-move-up ()
   "Test that moving a task up swaps it with its previous sibling."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "First")
@@ -433,7 +433,7 @@ Returns the note ID."
     (ekg-org-view-move-up))
   (should (equal (ekg-org-test--view-titles) '("First" "Third" "Second"))))
 
-(ekg-deftest ekg-org-test-view-move-down ()
+(ekg-deftest-with-db ekg-org-test-view-move-down ()
   "Test that moving a task down swaps it with its next sibling."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "First")
@@ -447,7 +447,7 @@ Returns the note ID."
     (ekg-org-view-move-down))
   (should (equal (ekg-org-test--view-titles) '("Second" "First" "Third"))))
 
-(ekg-deftest ekg-org-test-view-move-up-at-top ()
+(ekg-deftest-with-db ekg-org-test-view-move-up-at-top ()
   "Test that moving up at the top position is a no-op."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "First")
@@ -459,7 +459,7 @@ Returns the note ID."
     (ekg-org-view-move-up))
   (should (equal (ekg-org-test--view-titles) '("First" "Second"))))
 
-(ekg-deftest ekg-org-test-view-move-down-at-bottom ()
+(ekg-deftest-with-db ekg-org-test-view-move-down-at-bottom ()
   "Test that moving down at the bottom position is a no-op."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "First")
@@ -472,7 +472,7 @@ Returns the note ID."
     (ekg-org-view-move-down))
   (should (equal (ekg-org-test--view-titles) '("First" "Second"))))
 
-(ekg-deftest ekg-org-test-view-state-change ()
+(ekg-deftest-with-db ekg-org-test-view-state-change ()
   "Test that changing state updates the heading."
   (ekg-org-add-schema)
   (let ((id (ekg-org-test--add-task "My Task" nil "TODO")))
@@ -498,7 +498,7 @@ Returns the note ID."
                                       (line-beginning-position)
                                       (line-end-position)))))))
 
-(ekg-deftest ekg-org-test-view-insert-mode-sibling ()
+(ekg-deftest-with-db ekg-org-test-view-insert-mode-sibling ()
   "Test that insert mode creates a sibling after the current task."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "First")
@@ -519,7 +519,7 @@ Returns the note ID."
   (let ((titles (ekg-org-test--view-titles)))
     (should (equal titles '("First" "Second" "Third")))))
 
-(ekg-deftest ekg-org-test-view-insert-mode-child ()
+(ekg-deftest-with-db ekg-org-test-view-insert-mode-child ()
   "Test that insert mode creates a child task."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "Parent")
@@ -538,7 +538,7 @@ Returns the note ID."
   (let ((headings (ekg-org-test--view-headings)))
     (should (equal headings '((1 "Parent") (2 "Child"))))))
 
-(ekg-deftest ekg-org-test-view-insert-mode-top-level ()
+(ekg-deftest-with-db ekg-org-test-view-insert-mode-top-level ()
   "Test that insert mode creates a top-level task at the beginning."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "Existing")
@@ -557,7 +557,7 @@ Returns the note ID."
     (should (equal (car titles) "New First"))
     (should (= (length titles) 2))))
 
-(ekg-deftest ekg-org-test-view-insert-initial-position ()
+(ekg-deftest-with-db ekg-org-test-view-insert-initial-position ()
   "Test that insert mode defaults to first-child of the heading at point."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "Alpha")
@@ -581,7 +581,7 @@ Returns the note ID."
     (should (equal headings '((1 "Alpha") (2 "Alpha Child")
                               (1 "Beta") (2 "Beta Child"))))))
 
-(ekg-deftest ekg-org-test-view-top-level-spacing ()
+(ekg-deftest-with-db ekg-org-test-view-top-level-spacing ()
   "Test that blank lines separate top-level task groups after creation."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "Alpha")
@@ -602,7 +602,7 @@ Returns the note ID."
       (should (string-match-p "\n\n\\*" text)
               ))))
 
-(ekg-deftest ekg-org-test-view-insert-point-on-new-item ()
+(ekg-deftest-with-db ekg-org-test-view-insert-point-on-new-item ()
   "Test that point lands on the newly created item after insertion."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "First")
@@ -626,7 +626,7 @@ Returns the note ID."
                                   :titled/title))))
       (should (equal title "Second")))))
 
-(ekg-deftest ekg-org-test-view-insert-slot-after-subtree ()
+(ekg-deftest-with-db ekg-org-test-view-insert-slot-after-subtree ()
   "Test that the sibling-after slot is placed after the full subtree."
   (ekg-org-add-schema)
   (let* ((parent-id (ekg-org-test--add-task "Parent"))
@@ -659,7 +659,7 @@ Returns the note ID."
         (should (equal (plist-get target-slot :buffer-pos)
                        next-heading-pos))))))
 
-(ekg-deftest ekg-org-test-view-trash ()
+(ekg-deftest-with-db ekg-org-test-view-trash ()
   "Test that trashing a task removes it from the view."
   (ekg-org-add-schema)
   (ekg-org-test--add-task "Keep")
@@ -675,7 +675,7 @@ Returns the note ID."
     (should (= (length titles) 1))
     (should (equal (car titles) "Keep"))))
 
-(ekg-deftest ekg-org-test-view-trash-with-children ()
+(ekg-deftest-with-db ekg-org-test-view-trash-with-children ()
   "Test that trashing a task also trashes its children."
   (ekg-org-add-schema)
   (let* ((parent-id (ekg-org-test--add-task "Parent"))
@@ -699,7 +699,7 @@ Returns the note ID."
     (should-not (ekg-note-active-p (ekg-get-note-with-id child-id)))
     (should-not (ekg-note-active-p (ekg-get-note-with-id grandchild-id)))))
 
-(ekg-deftest ekg-org-test-view-archive-with-children ()
+(ekg-deftest-with-db ekg-org-test-view-archive-with-children ()
   "Test that archiving a task also archives its children."
   (ekg-org-add-schema)
   (let* ((parent-id (ekg-org-test--add-task "Archive Parent"))
@@ -721,7 +721,7 @@ Returns the note ID."
     (should (member ekg-org-archive-tag
                     (ekg-note-tags (ekg-get-note-with-id child-id))))))
 
-(ekg-deftest ekg-org-test-view-navigation ()
+(ekg-deftest-with-db ekg-org-test-view-navigation ()
   "Test heading navigation commands."
   (ekg-org-add-schema)
   (let* ((p1 (ekg-org-test--add-task "Parent 1"))
@@ -751,7 +751,7 @@ Returns the note ID."
                                     :titled/title))))
         (should (equal title "Parent 2"))))))
 
-(ekg-deftest ekg-org-test-view-deep-hierarchy ()
+(ekg-deftest-with-db ekg-org-test-view-deep-hierarchy ()
   "Test a three-level deep hierarchy renders correctly."
   (ekg-org-add-schema)
   (let* ((gp (ekg-org-test--add-task "Grandparent"))
@@ -761,7 +761,7 @@ Returns the note ID."
     (should (equal (ekg-org-test--view-headings)
                    '((1 "Grandparent") (2 "Parent") (3 "Child"))))))
 
-(ekg-deftest ekg-org-test-view-promote-to-grandparent ()
+(ekg-deftest-with-db ekg-org-test-view-promote-to-grandparent ()
   "Test promoting a deeply nested child to its grandparent's level."
   (ekg-org-add-schema)
   (let* ((gp (ekg-org-test--add-task "Grandparent"))
@@ -780,7 +780,7 @@ Returns the note ID."
       (should (member '(2 "Child") headings))
       (should (member '(2 "Parent") headings)))))
 
-(ekg-deftest ekg-org-test-view-auto-refresh-on-external-save ()
+(ekg-deftest-with-db ekg-org-test-view-auto-refresh-on-external-save ()
   "Test that the view refreshes when notes change outside of user actions.
 An agent saving a new note should cause the view to update automatically."
   (ekg-org-add-schema)
@@ -801,7 +801,7 @@ An agent saving a new note should cause the view to update automatically."
     (should (member "Agent Task" titles))
     (should (member "Initial Task" titles))))
 
-(ekg-deftest ekg-org-test-view-auto-refresh-on-external-delete ()
+(ekg-deftest-with-db ekg-org-test-view-auto-refresh-on-external-delete ()
   "Test that the view refreshes when a note is deleted externally."
   (ekg-org-add-schema)
   (let ((id (ekg-org-test--add-task "Doomed Task")))
@@ -814,7 +814,7 @@ An agent saving a new note should cause the view to update automatically."
       (should (= (length titles) 1))
       (should (equal (car titles) "Survivor")))))
 
-(ekg-deftest ekg-org-test-view-auto-refresh-on-external-state-change ()
+(ekg-deftest-with-db ekg-org-test-view-auto-refresh-on-external-state-change ()
   "Test that the view updates when a note's state changes externally."
   (ekg-org-add-schema)
   (let ((id (ekg-org-test--add-task "My Task" nil "TODO")))
@@ -840,7 +840,7 @@ An agent saving a new note should cause the view to update automatically."
                                       (line-beginning-position)
                                       (line-end-position)))))))
 
-(ekg-deftest ekg-org-test-view-refile-to-new-parent ()
+(ekg-deftest-with-db ekg-org-test-view-refile-to-new-parent ()
   "Test that refiling moves a task under a new parent."
   (ekg-org-add-schema)
   (let* ((p1 (ekg-org-test--add-task "Parent A"))
@@ -863,7 +863,7 @@ An agent saving a new note should cause the view to update automatically."
       (should (equal headings
                      '((1 "Parent A") (1 "Parent B") (2 "Child")))))))
 
-(ekg-deftest ekg-org-test-view-refile-to-top-level ()
+(ekg-deftest-with-db ekg-org-test-view-refile-to-top-level ()
   "Test that refiling to top level removes the parent."
   (ekg-org-add-schema)
   (let* ((parent (ekg-org-test--add-task "Parent"))
@@ -885,7 +885,7 @@ An agent saving a new note should cause the view to update automatically."
       (should (member '(1 "Parent") headings))
       (should (member '(1 "Child") headings)))))
 
-(ekg-deftest ekg-org-test-view-refile-excludes-descendants ()
+(ekg-deftest-with-db ekg-org-test-view-refile-excludes-descendants ()
   "Test that refile targets exclude the task itself and its descendants."
   (ekg-org-add-schema)
   (let* ((p (ekg-org-test--add-task "Parent"))
@@ -900,7 +900,7 @@ An agent saving a new note should cause the view to update automatically."
         (should (= (length choices) 1))
         (should (string= "Top level" (caar choices)))))))
 
-(ekg-deftest ekg-org-test-properties ()
+(ekg-deftest-with-db ekg-org-test-properties ()
   "Test generic org property get/set/remove."
   (ekg-org-add-schema)
   (let* ((id (ekg-org-test--add-task "Task with props"))
@@ -936,7 +936,7 @@ An agent saving a new note should cause the view to update automatically."
     (should (equal "other-branch" (ekg-org-get-property note "WORKTREE")))
     (should (= 1 (length (ekg-org-properties-alist note))))))
 
-(ekg-deftest ekg-org-test-view-insert-defers-refresh ()
+(ekg-deftest-with-db ekg-org-test-view-insert-defers-refresh ()
   "Test that refreshes during insert mode are deferred, not lost.
 When the user is positioning the insertion placeholder, an external
 note save must not re-render the buffer mid-interaction.  The

--- a/ekg-test-utils.el
+++ b/ekg-test-utils.el
@@ -25,6 +25,11 @@
 ;;; Code:
 
 
+(require 'cl-lib)
+(require 'seq)
+(require 'ert)
+
+
 (defmacro ekg--with-default-configuration (&rest body)
   "Remove any user hooks or custom options for testing.
 

--- a/ekg-test-utils.el
+++ b/ekg-test-utils.el
@@ -23,34 +23,111 @@
 ;; Helpers for testing out ekg, needed by multiple test files.
 
 ;;; Code:
+
+
+(defmacro ekg--with-default-configuration (&rest body)
+  "Remove any user hooks or custom options for testing.
+
+BODY are the expressions to run in this context."
+  (declare (debug t) (indent defun))
+  `(let ((ekg-add-schema-hook nil)
+         (ekg-note-pre-save-hook nil)
+         (ekg-note-save-hook nil)
+         (ekg-note-pre-delete-hook nil)
+         (ekg-note-delete-hook nil)
+         (ekg-note-add-tag-hook nil)
+         (ekg-confirm-on-buffer-kill nil))
+     (progn ,@body)))
+
+
+(defmacro ekg--with-buffer-cleanup (&rest body)
+  "Cleanup any buffers that are created.
+
+BODY are the expressions to run in this context."
+  (declare (debug t) (indent defun))
+  `(let ((orig-buffers (buffer-list)))
+     (unwind-protect
+         (progn ,@body)
+       (mapc #'kill-buffer (seq-difference (buffer-list) orig-buffers)))))
+
+
+(defmacro ekg--with-testing-env (&rest body)
+  "Run in an environment suitable for testing.
+
+BODY are the expressions to run in this context."
+  (declare (debug t) (indent defun))
+  `(ekg--with-default-configuration
+    (ekg--with-buffer-cleanup
+     (save-excursion ,@body))))
+
+
+(defmacro ekg--with-error-on-connect (&rest body)
+  "Mock `ekg-connect' to error when called.
+
+This allows us to ensure tests aren't trying to connect to a database
+when they shouldn't be.
+
+BODY are the expressions to run in this context."
+  (declare (debug t) (indent defun))
+  `(cl-letf (((symbol-function 'ekg-connect)
+              (lambda () (error "This test tried to use ekg-connect"))))
+     (progn ,@body)))
+
+
 (defmacro ekg-deftest (name _ &rest body)
-  "A test that will set up an empty `ekg-db' for use.
+  "A test that will setup a clean environment.
+
+This avoids tests interacting with preexisting resources, like the
+user's database.
+
 Argument NAME is the name of the testing function.
 BODY is the test body."
   (declare (debug t) (indent defun))
   `(ert-deftest ,name ()
-     (let ((ekg-db-file (make-temp-file "ekg-test"))
-           (ekg-db nil)
-           (orig-buffers (buffer-list))
-           ;; Remove hooks
-           (ekg-add-schema-hook nil)
-           (ekg-note-pre-save-hook nil)
-           (ekg-note-save-hook nil)
-           (ekg-note-pre-delete-hook nil)
-           (ekg-note-delete-hook nil)
-           (ekg-note-add-tag-hook nil)
-           (ekg-confirm-on-buffer-kill nil)
-           (id-count 0))
-       (cl-letf (((symbol-function 'ekg--generate-id)
-                  (lambda () (cl-incf id-count))))
-         (ekg-connect)
-         (triples-set-type ekg-db 'ekg 'ekg :version (version-to-list ekg-version))
-         (save-excursion
-           (unwind-protect
-               (progn ,@body)
-             (delete-file ekg-db-file)
-             ;; Kill all opened bufferes
-             (mapc #'kill-buffer (seq-difference (buffer-list) orig-buffers))))))))
+     (ekg--with-testing-env
+      (ekg--with-error-on-connect
+       ,@body))))
+
+
+(defmacro ekg--with-sequential-id-generation (&rest body)
+  "Number ids sequentially.
+
+This allows us to see what order they were generated in.
+
+BODY are the expressions to run in this context."
+  (declare (debug t) (indent defun))
+  `(let ((id-count 0))
+     (cl-letf (((symbol-function 'ekg--generate-id)
+                (lambda () (cl-incf id-count))))
+       (progn ,@body))))
+
+
+(defmacro ekg--with-testing-db (&rest body)
+  "Run in an environment with a clean database connection setup.
+
+BODY are the expressions to run in this context."
+  (declare (debug t) (indent defun))
+  `(ekg--with-testing-env
+    (ekg--with-sequential-id-generation
+     (let* ((ekg-db-dir (make-temp-file "ekg-test-dir" t))
+            (ekg-db-file (expand-file-name "db" ekg-db-dir))
+            (ekg-db nil)
+            (triples-default-database-filename nil))
+       (ekg-connect)
+       (triples-set-type ekg-db 'ekg 'ekg :version (version-to-list ekg-version))
+       ,@body))))
+
+
+(defmacro ekg-deftest-with-db (name _ &rest body)
+  "Run a test with a clean database connection already setup.
+
+Argument NAME is the name of the testing function.
+BODY is the test body."
+  (declare (debug t) (indent defun))
+  `(ert-deftest ,name ()
+     (ekg--with-testing-db
+      ,@body)))
+
 
 (provide 'ekg-test-utils)
 

--- a/ekg-test.el
+++ b/ekg-test.el
@@ -35,7 +35,7 @@
   "Counts words in the given TEXT string using forward-word in a temp buffer."
   (length (string-split text)))
 
-(ekg-deftest ekg-test-note-lifecycle ()
+(ekg-deftest-with-db ekg-test-note-lifecycle ()
              (let ((note (ekg-note-create :text "Test text" :mode 'text-mode :tags '("tag1" "tag2"))))
                (ekg-save-note note)
                ;; We should have an ID now.
@@ -51,7 +51,7 @@
                (should-not (ekg-live-id-p (ekg-note-id note)))
                (should (= 0 (length (ekg-get-notes-with-tags '("tag1" "tag2")))))))
 
-(ekg-deftest ekg-test-tags ()
+(ekg-deftest-with-db ekg-test-tags ()
              (should-not (ekg-tags))
              ;; Make sure we trim and lowercase all tags.
              (ekg-save-note (ekg-note-create :text "" :mode 'text-mode :tags '(" a" " B ")))
@@ -59,7 +59,7 @@
              (should (equal (ekg-tags-including "b") '("b")))
              (should (string= (ekg-tags-display '("a" "b")) "a, b")))
 
-(ekg-deftest ekg-test-org-link-to-id ()
+(ekg-deftest-with-db ekg-test-org-link-to-id ()
              (require 'ol)
              (let* ((note (ekg-note-create :text "" :mode 'text-mode :tags '("a" "b")))
                     (note-buf (ekg-edit note)))
@@ -81,7 +81,7 @@
                        (should (eq note-buf (current-buffer)))))
                  (kill-buffer note-buf))))
 
-(ekg-deftest ekg-test-org-link-to-tags ()
+(ekg-deftest-with-db ekg-test-org-link-to-tags ()
              (require 'ol)
              (ekg-save-note (ekg-note-create :text "" :mode 'text-mode :tags '("a" "b")))
              (ekg-show-notes-with-any-tags '("a" "b"))
@@ -103,7 +103,7 @@
                        (should (eq tag-buf (current-buffer)))))
                  (kill-buffer tag-buf))))
 
-(ekg-deftest ekg-test-url-handling ()
+(ekg-deftest-with-db ekg-test-url-handling ()
              (ekg-capture-url "http://testurl" "A URL used for testing")
              (insert "Text added to the URL")
              (ert-simulate-command '(ekg-capture-finalize))
@@ -117,14 +117,14 @@
                (ert-simulate-command '(ekg-capture-finalize)))
              (should (equal (ekg-document-titles) (list (cons "http://testurl/v2" "A URL used for testing")))))
 
-(ekg-deftest ekg-test-sort-nondestructive ()
+(ekg-deftest-with-db ekg-test-sort-nondestructive ()
              (mapc #'ekg-save-note
                    (list (ekg-note-create :text "a" :mode ekg-capture-default-mode :tags '("tag/a"))
                          (ekg-note-create :text "b" :mode ekg-capture-default-mode :tags '("tag/b"))))
              (ekg-show-notes-with-any-tags '("tag/b" "tag/a"))
              (should (string= ekg-notes-name "tags (any): tag/a, tag/b")))
 
-(ekg-deftest ekg-test-note-roundtrip ()
+(ekg-deftest-with-db ekg-test-note-roundtrip ()
              (let ((text "foo\n\tbar \"baz\" ☃"))
                (ekg-save-note (ekg-note-create :text text :mode #'text-mode :tags '("test")))
                (let ((note (car (ekg-get-notes-with-tag "test"))))
@@ -132,7 +132,7 @@
                  (should (equal text (ekg-note-text note)))
                  (should (equal 'text-mode (ekg-note-mode note))))))
 
-(ekg-deftest ekg-test-templating ()
+(ekg-deftest-with-db ekg-test-templating ()
              (ekg-save-note (ekg-note-create :text "ABC" :mode #'text-mode :tags '("test" "template")))
              (ekg-save-note (ekg-note-create :text "DEF" :mode #'text-mode :tags '("test" "template")))
              (let ((ekg-note-add-tag-hook '(ekg-on-add-tag-insert-template)))
@@ -141,7 +141,7 @@
                  (should (string-match (rx (literal "ABC")) text))
                  (should (string-match (rx (literal "DEF")) text)))))
 
-(ekg-deftest ekg-test-template-completion ()
+(ekg-deftest-with-db ekg-test-template-completion ()
              (ekg-save-note (ekg-note-create :text "ABC" :mode #'text-mode :tags '("test" "template")))
              (let ((ekg-note-add-tag-hook '(ekg-on-add-tag-insert-template)))
                (ekg-capture)
@@ -150,17 +150,17 @@
              (should (string-match (rx (literal "ABC")) (substring-no-properties (buffer-string))))
              (kill-buffer))
 
-(ekg-deftest ekg-test-get-notes-with-tags ()
+(ekg-deftest-with-db ekg-test-get-notes-with-tags ()
              (ekg-save-note (ekg-note-create :text "ABC" :mode #'text-mode :tags '("foo" "bar")))
              (should-not (ekg-get-notes-with-tags '("foo" "none")))
              (should-not (ekg-get-notes-with-tags '("none" "foo")))
              (should (= (length (ekg-get-notes-with-tags '("bar" "foo"))) 1)))
 
-(ert-deftest ekg-test-tag-to-hierarchy ()
+(ekg-deftest ekg-test-tag-to-hierarchy ()
   (should (equal (ekg-tag-to-hierarchy "foo/bar") '("foo" "foo/bar")))
   (should (equal (ekg-tag-to-hierarchy "foo") '("foo"))))
 
-(ekg-deftest ekg-test-extract-inlines ()
+(ekg-deftest-with-db ekg-test-extract-inlines ()
              (pcase (ekg-extract-inlines "Foo %(transclude 1) %n(transclude \"abc\") Bar")
                (`(,text . ,inlines)
                 (should (equal "Foo   Bar" text))
@@ -171,7 +171,7 @@
                          inlines)))
                (_ (ert-fail "Expected cons"))))
 
-(ekg-deftest ekg-test-extract-and-insert-inlines ()
+(ekg-deftest-with-db ekg-test-extract-and-insert-inlines ()
              (cl-loop for testcase in '("foo" "Foo %(transclude 1) %n(transclude \"abc\") Bar"
                                         "Foo%(transclude 1)%(transclude 2)Bar")
                       do
@@ -180,7 +180,7 @@
                                        (ekg-insert-inlines-representation
                                         (car ex-cons) (cdr ex-cons)))))))
 
-(ekg-deftest ekg-test-edit-note-display-text ()
+(ekg-deftest-with-db ekg-test-edit-note-display-text ()
              (let ((note (ekg-note-create :text "transcluded text" :mode 'org-mode :tags nil)))
                (ekg-save-note note)
                (ekg-capture :mode 'text-mode)
@@ -188,7 +188,7 @@
                (should (string-equal "Foo transcluded text bar"
                                      (ekg-edit-note-display-text)))))
 
-(ekg-deftest ekg-test-transclude ()
+(ekg-deftest-with-db ekg-test-transclude ()
              (let ((note1 (ekg-note-create :text "text1 text2" :mode 'org-mode :tags nil))
                    (note2 (ekg-note-create :text "text3 text4" :mode 'text-mode :tags nil)))
                (ekg-save-note note1)
@@ -200,7 +200,7 @@
                                        (ekg-insert-inlines-results
                                         (car ex-cons) (cdr ex-cons) nil))))))
 
-(ekg-deftest ekg-test-transclude-stability ()
+(ekg-deftest-with-db ekg-test-transclude-stability ()
              (let ((note (ekg-note-create :text "transcluded" :mode 'org-mode :tags nil)))
                (ekg-save-note note)
                (ekg-capture :tags '("tag"))
@@ -220,7 +220,7 @@
                    (ekg-edit transcluding-note)
                    (should (string-match transclude-txt (buffer-substring-no-properties (point-min) (point-max))))))))
 
-(ert-deftest ekg-test-inline-with-error ()
+(ekg-deftest ekg-test-inline-with-error ()
   (let ((target (concat "Inline: Error executing inline command "
                         "%(transclude-file \"/does/not/exist\"): ")))
     ;; We only want to compare to a certain point, since we don't want this test
@@ -233,7 +233,7 @@
                                                 :type 'command))
                          nil) 0 (length target))))))
 
-(ekg-deftest ekg-test-inline-storage ()
+(ekg-deftest-with-db ekg-test-inline-storage ()
              (let ((id)
                    (inlines (list
                              (make-ekg-inline :pos 3 :command '(transclude-file "transcluded") :type 'command)
@@ -260,7 +260,7 @@
                  (ekg-note-delete note)
                  (should (= 0 (length (triples-with-predicate ekg-db 'inline/command)))))))
 
-(ekg-deftest ekg-test-double-transclude-note ()
+(ekg-deftest-with-db ekg-test-double-transclude-note ()
              (let ((note (ekg-note-create :text "transclusion1" :mode 'text-mode :tags nil)))
                (ekg-save-note note)
                (ekg-capture :tags '("test1"))
@@ -275,7 +275,7 @@
                                      (ekg-display-note-text
                                       (car (ekg-get-notes-with-tag "test2"))))))
 
-(ekg-deftest ekg-get-notes-cotagged-with-tags ()
+(ekg-deftest-with-db ekg-get-notes-cotagged-with-tags ()
              (ekg-save-note (ekg-note-create :text "Foo" :tags '("magic" "a")))
              (ekg-save-note (ekg-note-create :text "Bar" :tags '("magic" "a/b")))
              (ekg-save-note (ekg-note-create :text "Baz" :tags '("magic" "c")))
@@ -285,7 +285,7 @@
                                     (ekg-get-notes-cotagged-with-tags '("a/b/child" "c") "magic"))
                             '("Foo" "Bar" "Baz"))))
 
-(ekg-deftest ekg-test-display-note-template ()
+(ekg-deftest-with-db ekg-test-display-note-template ()
              (let ((ekg-display-note-template
                     "%n(id)%n(tagged)%n(text 100)%n(other)%n(time-tracked)")
                    (note (ekg-note-create :text "text" :mode 'text-mode :tags '("tag1" "tag2"))))
@@ -301,12 +301,12 @@
                                          (ekg-display-note note ekg-display-note-template)))
                  (set-time-zone-rule nil))))
 
-(ert-deftest ekg-test-note-snippet ()
+(ekg-deftest ekg-test-note-snippet ()
   (should (equal "" (ekg-note-snippet (ekg-note-create :text "" :mode 'text-mode :tags nil))))
   (should (equal "foo" (ekg-note-snippet (ekg-note-create :text "foo" :mode 'text-mode :tags nil))))
   (should (equal "foo…" (ekg-note-snippet (ekg-note-create :text "foo bar" :mode 'text-mode :tags nil) 3))))
 
-(ekg-deftest ekg-test-header-line-metadata ()
+(ekg-deftest-with-db ekg-test-header-line-metadata ()
              (let ((ekg-capture-auto-tag-funcs nil))
                (ekg-capture :tags '("test"))
                ;; Check that header-line is set
@@ -314,7 +314,7 @@
                ;; Check that the header line contains the tag
                (should (string-match-p "test" header-line-format))))
 
-(ekg-deftest ekg-test-draft ()
+(ekg-deftest-with-db ekg-test-draft ()
              (ekg-capture :tags '("test"))
              (insert "foo")
              (ekg-save-draft)
@@ -332,7 +332,7 @@
                (should-not (member ekg-draft-tag (ekg-note-tags note))))
              (should (ekg-get-notes-with-tag "test")))
 
-(ekg-deftest ekg-test-draftless ()
+(ekg-deftest-with-db ekg-test-draftless ()
              (let ((ekg-draft-tag))
                (ekg-capture :tags '("test"))
                (insert "foo")
@@ -347,19 +347,19 @@
                  (should (equal "foo" (ekg-note-text note)))
                  (should-not (member ekg-draft-tag (ekg-note-tags note))))))
 
-(ert-deftest ekg-test-should-show-id-p ()
+(ekg-deftest ekg-test-should-show-id-p ()
   (should-not (ekg-should-show-id-p (ekg--generate-id)))
   (should (ekg-should-show-id-p "foo"))
   (should (ekg-should-show-id-p "http://gnu.org"))
   (should (ekg-should-show-id-p "/usr/bin/emacs")))
 
-(ekg-deftest ekg-test-rename ()
+(ekg-deftest-with-db ekg-test-rename ()
              (let ((note (ekg-note-create :text "foo" :mode 'text-mode :tags '("a" "b"))))
                (ekg-save-note note)
                (ekg-global-rename-tag "a" "b")
                (should (equal '("b") (ekg-note-tags (ekg-get-note-with-id (ekg-note-id note)))))))
 
-(ert-deftest ekg--populate-inline-tags ()
+(ekg-deftest ekg--populate-inline-tags ()
   (cl-flet ((assert-tag-population (text target-tags)
               (let ((note (make-ekg-note :text text)))
                 (ekg--populate-inline-tags note)
@@ -370,34 +370,34 @@
     (assert-tag-population "foo #[bar]\n@[baz]\n#[quux]" '("bar" "person/baz" "quux"))
     (assert-tag-population "foo [[bar]]" nil)))
 
-(ert-deftest ekg--populate-inline-tags-links-org ()
+(ekg-deftest ekg--populate-inline-tags-links-org ()
   (let ((note (make-ekg-note :text "link: #[[ekg-tag:foo][foo]]" :mode 'org-mode)))
     (ekg--populate-inline-tags note)
     (should (equal (ekg-note-tags note) '("foo")))))
 
-(ert-deftest ekg--populate-inline-tags-links-markdown-plain-tag ()
+(ekg-deftest ekg--populate-inline-tags-links-markdown-plain-tag ()
   (let ((note (make-ekg-note :text "link: [[foo]]" :mode 'markdown-mode)))
     (ekg--populate-inline-tags note)
     (should (equal (ekg-note-tags note) '("foo")))))
 
-(ert-deftest ekg--populate-inline-tags-links-markdown-special-tag ()
+(ekg-deftest ekg--populate-inline-tags-links-markdown-special-tag ()
   (let ((note (make-ekg-note :text "foo [[@foo]]" :mode 'markdown-mode)))
     (ekg--populate-inline-tags note)
     (should (equal (ekg-note-tags note) '("person/foo")))))
 
-(ert-deftest ekg--convert-inline-tags-to-links ()
+(ekg-deftest ekg--convert-inline-tags-to-links ()
   (let ((note (make-ekg-note :text "foo #[bar]")))
     (ekg--populate-inline-tags note)
     (ekg--convert-inline-tags-to-links note)
     (should (equal (ekg-note-text note) "foo #[[ekg-tag:bar][bar]]"))))
 
-(ert-deftest ekg-test-convert-emoji-tags-to-links ()
+(ekg-deftest ekg-test-convert-emoji-tags-to-links ()
   (let ((note (make-ekg-note :text "foo #[🦜]")))
     (ekg--populate-inline-tags note)
     (ekg--convert-inline-tags-to-links note)
     (should (equal (ekg-note-text note) "foo #[[ekg-tag:🦜][🦜]]"))))
 
-(ert-deftest test-ekg-truncate-at-word ()
+(ekg-deftest test-ekg-truncate-at-word ()
   "Test ekg-truncate-at with word-based truncation."
   (let ((ekg-truncation-method 'word)
         (english-text "This is a sample English text for testing truncation.")
@@ -412,7 +412,7 @@
       (let ((test-string (format "Should be %swill%s not trigger truncation" char char)))
         (should (string= (ekg-truncate-at test-string 50) test-string))))))
 
-(ert-deftest test-ekg-truncate-at-character ()
+(ekg-deftest test-ekg-truncate-at-character ()
   "Test ekg-truncate-at with character-based truncation."
   (let ((ekg-truncation-method 'character)
         (english-text "This is a sample English text for testing truncation.")
@@ -424,7 +424,7 @@
     (should (string= (ekg-truncate-at chinese-text 15) chinese-text))
     (should (string= (ekg-truncate-at chinese-text 20) chinese-text))))
 
-(ert-deftest test-ekg-embedding-text-selector-initial ()
+(ekg-deftest test-ekg-embedding-text-selector-initial ()
   "Test ekg-embedding-text-selector-initial with both truncation methods."
   (let ((short-english "Short English.") ;; 2 words, 15 chars
         (short-chinese "简短中文测试")      ;; 4 chars (effectively 4 words for char mode, 1 for word mode)
@@ -463,7 +463,7 @@
         ;; The primary check is that fewer words are returned than originally present.
         (should (= (ekg-test-count-words-in-string selected-text) 5460))))))
 
-(ekg-deftest ekg-test-embedding-refresh-skips-unfixable ()
+(ekg-deftest-with-db ekg-test-embedding-refresh-skips-unfixable ()
   "Refreshing a tag embedding skips notes whose embeddings can't be fixed."
   (let* ((good-embedding [0.1 0.2 0.3])
          (bad-embedding [0 0 0])
@@ -487,7 +487,7 @@
         ;; The good note's embedding should still be retrievable.
         (should (ekg-embedding-valid-p (ekg-embedding-get (ekg-note-id good-note))))))))
 
-(ert-deftest ekg-test-embedding-get-vecdb-returns-vector ()
+(ekg-deftest ekg-test-embedding-get-vecdb-returns-vector ()
   "When using vecdb, `ekg-embedding-get' returns the vector, not the struct."
   (let* ((ekg-vecdb-provider (cons :provider :collection))
          (expected-vector [0.1 0.2 0.3])
@@ -498,14 +498,14 @@
                (lambda (_item) expected-vector)))
       (should (equal (ekg-embedding-get 'note-id) expected-vector)))))
 
-(ert-deftest ekg-test-embedding-get-vecdb-returns-nil-when-missing ()
+(ekg-deftest ekg-test-embedding-get-vecdb-returns-nil-when-missing ()
   "When using vecdb and no item exists, `ekg-embedding-get' returns nil."
   (let ((ekg-vecdb-provider (cons :provider :collection)))
     (cl-letf (((symbol-function 'vecdb-get-item)
                (lambda (_provider _collection _embed-id) nil)))
       (should (eq (ekg-embedding-get 'note-id) nil)))))
 
-(ekg-deftest ekg-test-always-have-header-line ()
+(ekg-deftest-with-db ekg-test-always-have-header-line ()
              (ekg-capture)
              (should header-line-format)
              (ekg-change-mode 'text-mode)
@@ -514,7 +514,7 @@
                     (note-buf (ekg-edit note)))
                (should header-line-format)))
 
-(ekg-deftest ekg-test-notes-navigation ()
+(ekg-deftest-with-db ekg-test-notes-navigation ()
              (mapc #'ekg-save-note
                    (list (ekg-note-create :text "first" :mode 'text-mode :tags '("nav"))
                          (ekg-note-create :text "second" :mode 'text-mode :tags '("nav"))


### PR DESCRIPTION
Hi @ahyatt,

I've been thinking about your comment in #299. It seems to me there are two desirable properties here:

1. Tests should run in a clean environment, so they do not silently interact with existing user state.
2. Tests should fail if they try to connect to a database without one being explicitly provided.

This PR is an attempt at addressing **(1)** by making sure tests run with potentially dangerous variables `let`-bound to safe values.

Property **(2)** would also be useful, because it would give us a clean way to ensure some functionality does not depend on mutable database state, but it is a bit trickier to implement in practice.

## 1. Run tests in a clean environment

### Motivation

We want `ekg` tests to avoid interfering with any pre-existing user state. To do that, they should all run in a clean environment where potentially dangerous global variables are `let`-bound to safe values.

For tests that require a database, we explicitly set one up with `ekg-deftest-with-db`.

### Changes in this PR

In `ekg-test-utils`:

* `ekg-deftest` now only `let`-binds dangerous variables, it doesn't set up a database connection anymore.
* `ekg-deftest-with-db` was added to also set up a database connection. That is, it does what ekg-deftest used to do.

I then ran:

```sh
find . -type f -name '*test.el' \
  -exec sed -i 's/ekg-deftest/ekg-deftest-with-db/g' {} +
```

```sh
find . -type f -name '*test.el' \
  -exec sed -i 's/ert-deftest/ekg-deftest/g' {} +
```

and made sure that all `*test.el` files require `ekg-test-utils`.

## Why (2) is tricky

As things currently stand, even if a test uses `ekg-deftest` rather than `ekg-deftest-with-db`, `ekg-connect` still works. That is because `ekg-connect`, `triples-connect`, and `sqlite-open` are all a little too helpful.

To stop `ekg-connect` from silently connecting to an existing database, you need to `let`-bind:

* `ekg-db`
* `ekg-db-file`
* `triples-default-database-filename`

Even then, `sqlite-open` will still silently open an in-memory database.

Given that `ekg-deftest` currently `let`-binds `ekg-db-file` to a temporary test database, this is not too serious, since we are at least no longer silently testing against an existing user database. Still, it does bother me a bit that `ekg-connect` can keep working even when a database was not explicitly provided for the test.
