### PR TITLE
Fix note save failure from stale notes buffer refresh

### DIFF
--- a/ekg-test.el
+++ b/ekg-test.el
@@ -144,6 +144,21 @@
                                 (ekg-note-text
                                  (ekg-get-note-with-id (ekg-note-id note)))))))
 
+(ekg-deftest-with-db ekg-test-notes-refresh-reuses-highlight-overlay ()
+             (ekg-save-note (ekg-note-create :text "note"
+                                             :mode 'text-mode
+                                             :tags '("refresh")))
+             (ekg-show-notes-with-tag "refresh")
+             (let ((buf (get-buffer "*ekg tag: refresh*")))
+               (with-current-buffer buf
+                 (ekg-notes-refresh)
+                 (ekg-notes-refresh)
+                 (should
+                  (= 1 (cl-count-if
+                        (lambda (overlay)
+                          (eq (overlay-get overlay 'face) hl-line-face))
+                        (overlays-in (point-min) (point-max))))))))
+
 (ekg-deftest ekg-test-inline-images-suppress-org-parser-warning ()
   (with-temp-buffer
     (insert "[[attachment:foo.png]]\n")

--- a/ekg-test.el
+++ b/ekg-test.el
@@ -125,6 +125,25 @@
              (ekg-show-notes-with-any-tags '("tag/b" "tag/a"))
              (should (string= ekg-notes-name "tags (any): tag/a, tag/b")))
 
+(ekg-deftest-with-db ekg-test-edit-save-skips-stale-notes-buffer ()
+             (let* ((note (ekg-note-create :text "before"
+                                            :mode 'text-mode
+                                            :tags '("stale")))
+                    (stale-buf (get-buffer-create "*ekg stale notes*"))
+                    note-buf)
+               (ekg-save-note note)
+               (with-current-buffer stale-buf
+                 (ekg-notes-mode)
+                 (should-not ekg-notes-fetch-notes-function))
+               (setq note-buf (ekg-edit note))
+               (with-current-buffer note-buf
+                 (erase-buffer)
+                 (insert "after")
+                 (ekg-edit-save))
+               (should (string= "after"
+                                (ekg-note-text
+                                 (ekg-get-note-with-id (ekg-note-id note)))))))
+
 (ekg-deftest ekg-test-inline-images-suppress-org-parser-warning ()
   (with-temp-buffer
     (insert "[[attachment:foo.png]]\n")

--- a/ekg.el
+++ b/ekg.el
@@ -2080,7 +2080,11 @@ NAME is displayed at the top of the buffer."
     (ekg-notes-mode))
   (setq-local ekg-notes-fetch-notes-function notes-func
               ekg-notes-name name
-              ekg-notes-hl (make-overlay 1 1)
+              ekg-notes-hl (if (and (overlayp ekg-notes-hl)
+                                     (eq (overlay-buffer ekg-notes-hl)
+                                         (current-buffer)))
+                                ekg-notes-hl
+                              (make-overlay 1 1))
               ekg-notes-tags tags
               header-line-format (propertize (concat " " name)
                                              'face 'bold))

--- a/ekg.el
+++ b/ekg.el
@@ -2055,7 +2055,8 @@ cursor always lands on a note."
          (instance (vui--create-instance vnode nil))
          (vui--pending-effects nil))
     (setf (vui-instance-buffer instance) (current-buffer))
-    (ekg-notes-mode)
+    (unless (derived-mode-p 'ekg-notes-mode)
+      (ekg-notes-mode))
     (let ((inhibit-read-only t))
       (erase-buffer)
       (setq-local vui--root-instance instance)
@@ -2075,13 +2076,15 @@ cursor always lands on a note."
   "Display notes from NOTES-FUNC in buffer.
 New notes are created with additional tags TAGS.
 NAME is displayed at the top of the buffer."
-  (ekg--notes-mount name notes-func)
+  (unless (derived-mode-p 'ekg-notes-mode)
+    (ekg-notes-mode))
   (setq-local ekg-notes-fetch-notes-function notes-func
               ekg-notes-name name
               ekg-notes-hl (make-overlay 1 1)
               ekg-notes-tags tags
               header-line-format (propertize (concat " " name)
                                              'face 'bold))
+  (ekg--notes-mount name notes-func)
   (overlay-put ekg-notes-hl 'face hl-line-face)
   (ekg--note-highlight)
   (when (eq ekg-capture-default-mode 'org-mode)
@@ -2105,13 +2108,17 @@ NAME is displayed at the top of the buffer."
   (dolist (buf (buffer-list))
     (when (and (buffer-live-p buf)
                (with-current-buffer buf
-                 (derived-mode-p 'ekg-notes-mode)))
+                 (and (derived-mode-p 'ekg-notes-mode)
+                      (functionp ekg-notes-fetch-notes-function))))
       (with-current-buffer buf
         (ekg-notes-refresh)))))
 
 (defun ekg-notes-refresh ()
   "Refresh the current `ekg-notes' buffer."
   (interactive nil ekg-notes-mode)
+  (unless (functionp ekg-notes-fetch-notes-function)
+    (user-error
+     "This EKG notes buffer is missing its refresh function; recreate it"))
   (ekg--show-notes
    ekg-notes-name
    ekg-notes-fetch-notes-function


### PR DESCRIPTION
Saving an edited note refreshes all open EKG notes buffers.  If one of those buffers was in ekg-notes-mode but did not have ekg-notes-fetch-notes-function set, refresh passed nil as notes-func and VUI eventually called nil as a function.

Set notes-buffer refresh metadata before rendering, avoid reinitializing an already-active notes buffer, and skip stale notes buffers during global refresh.